### PR TITLE
Corregido mapeanto de botón continuar en una vista

### DIFF
--- a/core/apps/base/urls.py
+++ b/core/apps/base/urls.py
@@ -2,10 +2,11 @@
 
 from django.urls import path
 
-from core.apps.base.views import ContactWizard
+from core.apps.base.views import ContactWizard, finalizado
 
 app_name = 'base'
 
 urlpatterns = [
-    path('', ContactWizard.as_view(), name='home')
+    path('', ContactWizard.as_view(), name='home'),
+    path('finalizado/', finalizado, name='done')
 ]


### PR DESCRIPTION
- Implementada nueva ruta -> `/finalizado`

Al llegar al `done`, este recibe un request POST, y allí dentro se hace el redirect hacia `finalizado` y junto al session se envia la información obtenida de los formularios.

La view finalizado es responsbale por renderizar la ruta `/finalizado` y estará lista para cargar la información del radicado cuando sea necesario. 

En caso de acceder a esa ruta sin haber venido de los pasos, entonces será dirigido hacia el home (`'/'`)