### PR TITLE
218 enviar sms de confirmación

### DIFF
--- a/core/apps/base/forms.py
+++ b/core/apps/base/forms.py
@@ -334,7 +334,7 @@ class DigitaCelular(forms.Form):
             # Si llega aquí es pq el celular ha sido validado en el front
             cleaned_data.update({'celular_validado': True})
         else:
-            tipo_documento, documento, municipio_data = '', '', {}
+            tipo_documento, documento, municipio_data = '', '', ''
             if self.wizard:
                 # Access raw step data without triggering validation/API calls
                 previous_data = self._get_previous_step_data()

--- a/core/apps/base/pipelines.py
+++ b/core/apps/base/pipelines.py
@@ -3,6 +3,7 @@ from typing import Tuple
 
 from core.apps.base.models import Radicacion
 from core.apps.base.resources.email_helpers import Email
+from core.apps.base.resources.sms_helpers import send_sms_confirmation
 from core.apps.tasks.utils.gdrive import GDriveHandler
 from core.settings import logger as log, DEBUG
 
@@ -28,9 +29,12 @@ class NotifyEmail(PostStep, Email):
 
 
 class NotifySMS(PostStep):
+
+    def __init__(self, **kwargs):
+        ...
+
     def proceed(self, info_email: dict, rad_id: str) -> Tuple[bool, dict]:
-        # TODO Pendiente de implementar
-        # log.info(f"{info_email['log_text']} ...enviando SMS.")
+        send_sms_confirmation(info_email.get('celular'), rad_id, info_email.get('P_NOMBRE'))
         check = True
         return check, info_email
 

--- a/core/apps/base/resources/api_calls.py
+++ b/core/apps/base/resources/api_calls.py
@@ -6,7 +6,7 @@ from typing import Tuple, Dict
 import requests
 from decouple import config
 from django.template.loader import get_template
-from pymssql import Connection
+# from pymssql import Connection
 from requests import Timeout
 from urllib3.exceptions import NewConnectionError, MaxRetryError
 

--- a/core/apps/base/resources/fake.json
+++ b/core/apps/base/resources/fake.json
@@ -1,38 +1,107 @@
 {
-   "TIPO_IDENTIFICACION":"CC",
-   "DOCUMENTO_ID":"12340316",
-   "AFILIADO":"GUTIERREZ TEIXEIRA JACKSON WOH",
-   "P_NOMBRE":"JACKSON",
-   "S_NOMBRE":"WOH",
-   "P_APELLIDO":"GUTIERREZ","S_APELLIDO":"TEIXEIRA",
-   "ESTADO_AFILIADO":"ACTIVO",
-   "SEDE_AFILIADO":"BARRANCABERMEJA",
-   "REGIMEN":"SUBSIDIADO",
-   "DIRECCION":"CL 123  45 678",
-   "CORREO":"jackson.gutierrez.teixeira123456789@gmail.com",
-   "TELEFONO":"4019255",
-   "CELULAR":"4014652512",
-   "ESTADO_AUTORIZACION":"PROCESADA",
-   "FECHA_AUTORIZACION":"15/11/2022",
-   "MEDICO_TRATANTE":"FRANK LAMPARD",
-   "MIPRES":"0",
-   "DIAGNOSTICO":"D571-ANEMIA FALCIFORME SIN CRISIS",
-   "ARCHIVO": "",
-   "DETALLE_AUTORIZACION":[
-      {
-         "CUMS":"20158642-1",
-         "NOMBRE_PRODUCTO":"RIVAROXABAN 20MG TABLETA RECUBIERTA",
-         "CANTIDAD":"30"
-      },
-      {
-         "CUMS":"42034-1",
-         "NOMBRE_PRODUCTO":"HIDROXIUREA 500MG CAPSULA",
-         "CANTIDAD":"60"
-      }
-   ],
-   "municipio":"Barrancamerbeja, Santander",
-   "barrio":"Any Neighbor, Florida",
-   "direccion":"321654987654",
-   "celular":9151234567,
-   "email":"23131@gmail.com"
+  "TIPO_IDENTIFICACION": "CC",
+  "DOCUMENTO_ID": "12340316",
+  "AFILIADO": "GUTIERREZ TEIXEIRA JACKSON WOH",
+  "P_NOMBRE": "JACKSON",
+  "S_NOMBRE": "WOH",
+  "P_APELLIDO": "GUTIERREZ",
+  "S_APELLIDO": "TEIXEIRA",
+  "ESTADO_AFILIADO": "ACTIVO",
+  "SEDE_AFILIADO": "BARRANCABERMEJA",
+  "REGIMEN": "SUBSIDIADO",
+  "DIRECCION": "CL 123  45 678",
+  "CORREO": "jackson.gutierrez.teixeira123456789@gmail.com",
+  "TELEFONO": "4019255",
+  "CELULAR": "4014652512",
+  "ESTADO_AUTORIZACION": "PROCESADA",
+  "FECHA_AUTORIZACION": "15/11/2022",
+  "MEDICO_TRATANTE": "FRANK LAMPARD",
+  "MIPRES": "0",
+  "DIAGNOSTICO": "D571-ANEMIA FALCIFORME SIN CRISIS",
+  "ARCHIVO": "",
+  "DETALLE_AUTORIZACION": [
+    {
+      "CUMS": "20158642-1",
+      "NOMBRE_PRODUCTO": "RIVAROXABAN 20MG TABLETA RECUBIERTA",
+      "CANTIDAD": "30"
+    },
+    {
+      "CUMS": "42034-1",
+      "NOMBRE_PRODUCTO": "HIDROXIUREA 500MG CAPSULA",
+      "CANTIDAD": "60"
+    }
+  ],
+  "municipio": "Barrancamerbeja, Santander",
+  "barrio": "Any Neighbor, Florida",
+  "direccion": "321654987654",
+  "celular": 9151234567,
+  "email": "notiene@gmail.com",
+  "NOMBRE": "GUTIERREZ TEIXEIRA JACKSON WOH",
+  "PRIMER_APELLIDO": "GUTIERREZ",
+  "PRIMER_NOMBRE": "JACKSON",
+  "status": "ACTIVO",
+  "resultado_scrapper": [
+    {
+      "ESTADO": "Radicada",
+      "DOCUMENTO": 12340316,
+      "DISPENSADO": true,
+      "RADICADO_AT": "",
+      "TIPO_DOCUMENTO": "Cedula de Ciudadania",
+      "NUMERO_AUTORIZACION": "12345678901",
+      "DETALLE_AUTORIZACION": [
+        {
+          "CANTIDAD": "28",
+          "NOMBRE_PRODUCTO": "M00835 DAPAGLIFLOZINA 10.MG/1.U TABLETA RECUBIERTA"
+        }
+      ]
+    },
+    {
+      "ESTADO": "Radicada",
+      "DOCUMENTO": 12340316,
+      "DISPENSADO": false,
+      "RADICADO_AT": "",
+      "TIPO_DOCUMENTO": "Cedula de Ciudadania",
+      "NUMERO_AUTORIZACION": "12345678902",
+      "DETALLE_AUTORIZACION": [
+        {
+          "CANTIDAD": "8",
+          "NOMBRE_PRODUCTO": "M02029 ERITROPOYETINA 2000.UI/1.U POLVO LIOFILIZADO PARA RECONSTITUIR A SOLUCION INYECTABLE"
+        }
+      ]
+    },
+    {
+      "DOCUMENTO": 12340316,
+      "DISPENSADO": false,
+      "TIPO_DOCUMENTO": "Cedula de Ciudadania",
+      "NUMERO_AUTORIZACION": "12345678903",
+      "DETALLE_AUTORIZACION": [
+        {
+          "CANTIDAD": "8",
+          "NOMBRE_PRODUCTO": "M02029 ERITROPOYETINA 2000.UI/1.U POLVO LIOFILIZADO PARA RECONSTITUIR A SOLUCION INYECTABLE"
+        }
+      ]
+    },
+    {
+      "ESTADO": "(En Proceso)",
+      "DOCUMENTO": 12340316,
+      "DISPENSADO": false,
+      "RADICADO_AT": "el 27 de Mayo a las 02:23 PM",
+      "TIPO_DOCUMENTO": "Cedula de Ciudadania",
+      "NUMERO_AUTORIZACION": "12345678904",
+      "DETALLE_AUTORIZACION": [
+        {
+          "CANTIDAD": "30",
+          "NOMBRE_PRODUCTO": "M03228 IRBESARTAN 300.MG/1.U TABLETA"
+        },
+        {
+          "CANTIDAD": "8",
+          "NOMBRE_PRODUCTO": "M02029 ERITROPOYETINA 2000.UI/1.U POLVO LIOFILIZADO PARA RECONSTITUIR A SOLUCION INYECTABLE"
+        },
+        {
+          "CANTIDAD": "1",
+          "NOMBRE_PRODUCTO": "M02790 INSULINA GLARGINA 100.UI/1.ML SOLUCION INYECTABLE"
+        }
+      ]
+    }
+  ]
 }

--- a/core/apps/base/resources/sms_helpers.py
+++ b/core/apps/base/resources/sms_helpers.py
@@ -43,7 +43,7 @@ def send_sms_verification_code(cel: int, otp_code: int):
     return Sms(cel).send_sms(f"{otp_code}: código de verificación de Logifarma. No lo compartas.")
 
 def send_sms_confirmation(cel: int, numero_autorizacion: str, p_nombre: str):
-    """Send a verification code."""
+    """Send a confirmation message."""
     numero_autorizacion = numero_autorizacion.replace('#', '')
     hola = f"Hola {p_nombre.title()}".strip()
     return Sms(cel).send_sms(f"Logifarma: {hola}, Tu solicitud de entrega a domicilio Nº{numero_autorizacion} fue realizada con éxito!.")

--- a/core/apps/base/resources/sms_helpers.py
+++ b/core/apps/base/resources/sms_helpers.py
@@ -1,6 +1,7 @@
 from decouple import config
 
 from core.apps.base.resources.movistar import ApiMovistar
+from core.settings import PRODUCTION
 
 
 class Sms(ApiMovistar):
@@ -31,6 +32,8 @@ class Sms(ApiMovistar):
 
     def send_sms(self, message: str):
         """Send an sms message."""
+        if not PRODUCTION:
+            return True
         resp = self.post(f"{self.MOVISTAR_URL}{self.MESSAGE}", self.payload_sms(message))
         return not bool(resp.get('ERROR'))
 
@@ -39,6 +42,8 @@ def send_sms_verification_code(cel: int, otp_code: int):
     """Send a verification code."""
     return Sms(cel).send_sms(f"{otp_code}: código de verificación de Logifarma. No lo compartas.")
 
-def send_sms_confirmation(cel: int, rad_number: int):
+def send_sms_confirmation(cel: int, numero_autorizacion: str, p_nombre: str):
     """Send a verification code."""
-    # TODO
+    numero_autorizacion = numero_autorizacion.replace('#', '')
+    hola = f"Hola {p_nombre.title()}".strip()
+    return Sms(cel).send_sms(f"Logifarma: {hola}, Tu solicitud de entrega a domicilio Nº{numero_autorizacion} fue realizada con éxito!.")

--- a/core/apps/base/resources/tools.py
+++ b/core/apps/base/resources/tools.py
@@ -199,7 +199,7 @@ def guardar_info_bd(**kwargs):
     rad = kwargs.pop('NUMERO_AUTORIZACION', None)
     convenio = kwargs.pop('CONVENIO', None)
     if Radicacion.objects.filter(numero_radicado=str(rad), convenio=convenio).exists():
-        logger.info(f"{rad} Número de radicación ya existe!.")
+        logger.warning(f"{rad} Número de radicación ya existe!.")
         return
     municipio = kwargs.pop('municipio').name.lower()
 
@@ -263,7 +263,7 @@ def save_in_bd(name_bd: str, rad):
         logger.info(f"{rad.numero_radicado} Radicación guardada con éxito {rad.id=}")
 
 
-def guardar_short_info_bd(**kwargs) -> Tuple[str, str, str]:
+def guardar_short_info_bd(**kwargs):
     """
     Guarda radicado en base de datos
     :param kwargs: Información final del wizard + ip:
@@ -272,7 +272,6 @@ def guardar_short_info_bd(**kwargs) -> Tuple[str, str, str]:
     :return:
     """
     from core.apps.base.models import Radicacion, Municipio, Barrio
-    # resp = ('', '', '')
     municipio = kwargs.pop('municipio').name.lower()
 
     email = kwargs.pop('email', None)

--- a/core/apps/base/scrapper_requests.py
+++ b/core/apps/base/scrapper_requests.py
@@ -735,7 +735,7 @@ class JSFPortalScraper:
                         # Fila {i}. Se esperaba Nro de Autorización en modal de 'Ver' pero no fue encontrado."
                         ...
             if not nro_aut:
-                # Se intentó dos veces encontrar el Nro de Aut en modal de ver pero no fue posible, reinicia scrapper
+                log.error(f"Fila {i}. Se intentó dos veces encontrar el Nro de Aut en modal de ver pero no fue posible, reinicia scrapper")
                 raise RestartScrapper
             auts.append(self.parse_aut_and_meds(nro_aut, meds))
             nro_aut = ''
@@ -809,6 +809,6 @@ class MutualScrapper(JSFPortalScraper):
 
 
 if __name__ == '__main__':
-    scrapper = MutualScrapper('CC', '123456789')
+    scrapper = MutualScrapper('CC', '92256603')
     result = scrapper.find_user()
     pprint(result)

--- a/core/apps/base/templates/notifiers/correo.html
+++ b/core/apps/base/templates/notifiers/correo.html
@@ -544,7 +544,7 @@
                                     <td align="right"
                                         style="font-size: 0px; padding: 10px 25px; padding-top: 0px; padding-bottom: 0px; word-break: break-word;">
                                         <div style="font-family: Arial, sans-serif; font-size: 13px; letter-spacing: normal; line-height: 1; text-align: right; color: #000000b5;">
-                                            <h3><span style="font-family: Arial; font-size: 18px;">{% if CONVENIO == 'mutualser' %} Mutual Ser {% else %} {{CONVENIO|title}} {% endif %}</span>
+                                            <h3><span style="font-family: Arial; font-size: 18px;">{% if CONVENIO == 'mutualser' %} Mutualser {% else %} {{CONVENIO|title}} {% endif %}</span>
                                             </h3>
                                         </div>
                                     </td>

--- a/core/apps/base/templates/notifiers/correo_sin_autorizacion.html
+++ b/core/apps/base/templates/notifiers/correo_sin_autorizacion.html
@@ -329,7 +329,7 @@
                                     <td align="right"
                                         style="font-size: 0px; padding: 10px 25px; padding-top: 0px; padding-bottom: 0px; word-break: break-word;">
                                         <div style="font-family: Arial, sans-serif; font-size: 13px; letter-spacing: normal; line-height: 1; text-align: right; color: #000000b5;">
-                                            <h3><span style="font-family: Arial; font-size: 18px;">{% if CONVENIO == 'mutualser' %} Mutual Ser {% else %} {{CONVENIO|title}} {% endif %}</span>
+                                            <h3><span style="font-family: Arial; font-size: 18px;">{% if CONVENIO == 'mutualser' %} Mutualser {% else %} {{CONVENIO|title}} {% endif %}</span>
                                             </h3>
                                         </div>
                                     </td>

--- a/core/apps/base/views.py
+++ b/core/apps/base/views.py
@@ -142,6 +142,8 @@ class ContactWizard(CustomSessionWizard):
         ip = self.request.META.get('HTTP_X_FORWARDED_FOR', self.request.META.get('REMOTE_ADDR'))
         if info_email['NUMERO_AUTORIZACION'] not in [99_999_999, 99_999_998]:
             rad = guardar_info_bd(**info_email, ip=ip)
+        else:
+            rad = Radicacion(cel_uno=form_data['digitaCelular']['celular'], numero_radicado=info_email['NUMERO_AUTORIZACION'])
 
         logger.info(f"{self.request.COOKIES.get('sessionid')[:6]} {info_email['NUMERO_AUTORIZACION']}"
                     f" Radicación finalizada. E-mail de confirmación será enviado a {form_data['digitaCorreo']}")
@@ -158,7 +160,7 @@ class ContactWizard(CustomSessionWizard):
             x.start()
         else:
             self.send_mail(info_email)
-            send_sms_confirmation(rad.cel_uno, rad.numero_autorizacion, kwargs.get('P_NOMBRE', ''))
+            send_sms_confirmation(form_data.get('digitaCelular', {}).get('celular', ''), rad.numero_autorizacion, kwargs.get('P_NOMBRE', ''))
 
         return form_data['autorizacionServicio']['num_autorizacion']
 

--- a/core/apps/base/views_mutualser.py
+++ b/core/apps/base/views_mutualser.py
@@ -60,7 +60,7 @@ class DocumentoMutualSer(forms.Form):
         entidad = 'mutualser'
         resp = {'documento': f"{tipo}{value}"}
 
-        if int(value) == 99_999_999:
+        if value == '99999999':
             resp_eps = read_json('resources/fake.json')
             scrapper = ScrapMutualSer(tipo_documento=tipo, documento=value,
                                       estado='completado', resultado=resp_eps['resultado_scrapper'])
@@ -70,7 +70,7 @@ class DocumentoMutualSer(forms.Form):
         resp_eps = resp_eps or Mutualser.get_afiliado_by_doc(tipo, value)
         validate_empty_response(resp_eps, resp['documento'], entidad)
 
-        if int(value) == 99_999_999:
+        if value == '99999999':
             # scrapper ha sido creado
             ...
         else:

--- a/core/apps/base/views_sin_autorizacion.py
+++ b/core/apps/base/views_sin_autorizacion.py
@@ -87,6 +87,7 @@ class SinAutorizacion(CustomSessionWizard):
             rad = guardar_short_info_bd(**info_email, ip=ip)
             info_email['NUMERO_RADICACION'] = rad.numero_autorizacion
             info_email['FECHA_RADICACION'] = rad.datetime
+            info_email['ref_id'] = rad.numero_radicado
             rad_id = rad.numero_autorizacion
         else:
             rad_id = '1'

--- a/core/settings.py
+++ b/core/settings.py
@@ -32,6 +32,7 @@ CSRF_TRUSTED_ORIGINS = ["https://*.sa.ngrok.io", "https://*.ngrok.io"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config("DEBUG", cast=bool)
+PRODUCTION = config("PRODUCTION", cast=bool, default=True)
 
 ALLOWED_HOSTS = ['domicilios.logifarma.com.co',
                  'radicatudomicilio.herokuapp.com',

--- a/core/settings.py
+++ b/core/settings.py
@@ -32,7 +32,7 @@ CSRF_TRUSTED_ORIGINS = ["https://*.sa.ngrok.io", "https://*.ngrok.io"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config("DEBUG", cast=bool)
-PRODUCTION = config("PRODUCTION", cast=bool, default=True)
+PRODUCTION = config("PRODUCTION", cast=bool, default=False)
 
 ALLOWED_HOSTS = ['domicilios.logifarma.com.co',
                  'radicatudomicilio.herokuapp.com',


### PR DESCRIPTION
## Summary by Sourcery

Integrate SMS confirmation in the booking workflow, refactor email and database helpers for consistency, and introduce a fake scrapper data path for testing identifier 99999999.

New Features:
- Add send_sms_confirmation helper and integrate SMS notifications via a new NotifySMS post step in relevant wizards
- Support loading fake scrapper data from fake.json for the 99_999_999 test identifier

Enhancements:
- Embed DNS MX lookup within validar_email and simplify email subject generation
- Refactor guardar_info_bd and guardar_short_info_bd to remove otp_code, consistently pop celular_validado, return rad objects, and improve duplicate Barrio error handling and logging
- Add PRODUCTION setting to disable SMS sending outside production and guard Movistar API calls