### PR TITLE
243 agregar columna en artículos en vista de radicación

### DIFF
--- a/core/apps/api/exception_handlers.py
+++ b/core/apps/api/exception_handlers.py
@@ -1,0 +1,19 @@
+# core/apps/api/exception_handlers.py
+from django.db.utils import OperationalError
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+
+def api_exception_handler(exc, context):
+    response = exception_handler(exc, context)
+    if response is not None:
+        return response
+
+    if isinstance(exc, OperationalError):
+        return Response(
+            {'detail': 'Base de datos temporalmente no disponible. Intente nuevamente.'},
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    return None

--- a/core/apps/api/serializers.py
+++ b/core/apps/api/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 
 from core.apps.base.models import Barrio, Municipio, SearchBarra, Radicacion, SAPArticle
 from core.apps.base.exceptions import DriveFileIdNormalizationError
+from core.apps.base.resources.medicar import HistoricoDispensados
 from core.apps.tasks.utils.gdrive import normalize_drive_file_id
 
 
@@ -178,4 +179,14 @@ class SearchBarraSerializer(serializers.ModelSerializer):
 
     def get_cached(self, obj) -> bool:
         return self.context.get('cached', False)
-        
+
+
+class HistoricalDispensacionesResponseSerializer(serializers.BaseSerializer):
+    """
+    Expone la lista validada de historico-dispensaciones (Medicar) como JSON.
+    La instancia debe ser ``HistoricoDispensados`` (modelo Pydantic RootModel).
+    """
+
+    def to_representation(self, instance: HistoricoDispensados) -> list[dict]:
+        return instance.model_dump_list()
+

--- a/core/apps/api/tests/test_historical_dispensaciones.py
+++ b/core/apps/api/tests/test_historical_dispensaciones.py
@@ -1,0 +1,91 @@
+"""Tests for GET /api/v1/historical-dispensations/<documento>/ and Pydantic parsing."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import SimpleTestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from core.apps.base.resources.medicar import HistoricoDispensados
+
+SAMPLE_HISTORICO = [
+    {
+        'TipoDoc': 'CC',
+        'NumeroDocumento': '22479430',
+        'Afiliado': 'PACIENTE TEST',
+        'PendientesActivos': True,
+        'SSCs': [
+            {
+                'SSC': 9915040,
+                'SubPlan': 'Capita complementaria Subsidiado',
+                'Autorizacion': '',
+                'MIPRES': '',
+                'FecSol': '2026-05-08 07:48:43',
+                'Centro': '920',
+                'NombCaf': 'Central Domicilios Barranquilla (920)',
+                'Articulos': [
+                    {
+                        'CodMol': 22501,
+                        'Plu': '7707334710348',
+                        'Descripcion': 'FOSFOMICINA 3 MG POLVO ORAL',
+                        'CantidadSolicitada': 24,
+                        'CantidadPendiente': 24,
+                        'InventarioMoleculaCentro': 7,
+                        'TotalPendienteMoleculaCentro': 35,
+                        'TransitoMoleculaCentro': 30,
+                        'Dispensaciones': [
+                            {
+                                'CantidadDispensada': 5,
+                                'FecDisp': '2026-05-08 07:48:43',
+                            },
+                            {
+                                'CantidadDispensada': 3,
+                                'FecDisp': '2026-05-09 08:00:00',
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+]
+
+
+class HistoricoDispensadosPydanticTests(SimpleTestCase):
+    """No database required."""
+
+    def test_sum_cantidad_dispensada_por_cod_mol(self) -> None:
+        h = HistoricoDispensados.model_validate(SAMPLE_HISTORICO)
+        self.assertEqual(h.sum_cantidad_dispensada_por_cod_mol(22501), 8)
+        self.assertEqual(h.sum_cantidad_dispensada_por_cod_mol(99999), 0)
+
+
+class HistoricalDispensacionesApiTests(APITestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create_user('historico_tester', password='historico-pass')
+        self.url = reverse('historical_dispensaciones', kwargs={'documento': '22479430'})
+
+    def test_requires_auth(self) -> None:
+        res = self.client.get(self.url)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch('core.apps.api.views.obtener_historico_dispensados_usuario')
+    def test_returns_json_list_when_authenticated(self, mock_med: object) -> None:
+        mock_med.return_value = SAMPLE_HISTORICO
+        self.client.force_login(self.user)
+        res = self.client.get(self.url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(res.data), 1)
+        self.assertEqual(res.data[0]['NumeroDocumento'], '22479430')
+        mock_med.assert_called_once_with('22479430')
+
+    @patch('core.apps.api.views.obtener_historico_dispensados_usuario')
+    def test_non_list_response_is_502(self, mock_med: object) -> None:
+        mock_med.return_value = {'error': 'unexpected'}
+        self.client.force_login(self.user)
+        res = self.client.get(self.url)
+        self.assertEqual(res.status_code, status.HTTP_502_BAD_GATEWAY)
+        self.assertIn('detail', res.data)

--- a/core/apps/api/urls.py
+++ b/core/apps/api/urls.py
@@ -5,6 +5,7 @@ from rest_framework.routers import DefaultRouter
 from .views import (
     RadicacionViewSet,
     busca_paciente,
+    historical_dispensaciones,
     prescription_ocr_barra_poll,
     prescription_ocr_discard,
     prescription_ocr_run,
@@ -20,6 +21,11 @@ urlpatterns = [
     path('docs/', SpectacularSwaggerView.as_view(url_name='api-schema'),
          name='api-docs'),
     path("prescription-ocr/", prescription_ocr_run, name="prescription_ocr_run"),
+    path(
+        "historical-dispensations/<str:documento>/",
+        historical_dispensaciones,
+        name="historical_dispensaciones",
+    ),
     path(
         "prescription-ocr/barra/<int:job_id>/",
         prescription_ocr_barra_poll,

--- a/core/apps/api/views.py
+++ b/core/apps/api/views.py
@@ -330,7 +330,7 @@ def prescription_ocr_run(request) -> Response:
         )
     if outcome.error == 'llm':
         return Response(
-            {'detail': 'El servicio de OCR falló. Intente de nuevo más tarde.'},
+            {'detail': f'El servicio de OCR falló. {outcome.reason or ""}'},
             status=status.HTTP_502_BAD_GATEWAY,
         )
 

--- a/core/apps/api/views.py
+++ b/core/apps/api/views.py
@@ -11,16 +11,23 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from core.apps.base.resources.medicar import MedicarFormulaSchema
+from pydantic import ValidationError
+
+from core.apps.base.resources.medicar import (
+    MedicarFormulaSchema,
+    obtener_historico_dispensados_usuario,
+    validate_historico_dispensados,
+)
 
 from .serializers import (
-    PrescriptionOCRDiscardSerializer, 
+    HistoricalDispensacionesResponseSerializer,
+    PrescriptionOCRDiscardSerializer,
     SearchBarraSerializer,
-    PrescriptionOCRRunSerializer, 
-    RadicacionDetailSerializer, 
-    RadicacionPartialUpdateSerializer, 
-    RadicacionSerializer, 
-    RadicacionWriteSerializer
+    PrescriptionOCRRunSerializer,
+    RadicacionDetailSerializer,
+    RadicacionPartialUpdateSerializer,
+    RadicacionSerializer,
+    RadicacionWriteSerializer,
 )
 from ..base.exceptions import OcrLockBusy
 from ..base.models import Barrio, Municipio, SearchBarra, Radicacion, ScrapMutualSer, Status, OtpSMS
@@ -375,6 +382,41 @@ def prescription_ocr_barra_poll(request, job_id: int) -> Response:
 
     log.info(f"{cached=} for {article_nombre=!r} {ips=!r} -> {job}")
     return Response(SearchBarraSerializer(poll_barra_job(job), context={'cached': cached}).data)
+
+
+@extend_schema(
+    summary='Histórico de dispensaciones (Medicar)',
+    description=(
+        'Consulta el histórico de dispensaciones por número de documento del paciente. '
+        'Respuesta en el mismo formato que devuelve la API Medicar (lista de objetos).'
+    ),
+)
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def historical_dispensaciones(request, documento: str) -> Response:
+    documento_clean = (documento or '').strip()
+    if not documento_clean:
+        return Response(
+            {'detail': 'Número de documento inválido.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    try:
+        raw = obtener_historico_dispensados_usuario(documento_clean)
+        parsed = validate_historico_dispensados(raw)
+    except TypeError as exc:
+        log.warning('historical_dispensaciones: respuesta inesperada %s', exc)
+        return Response(
+            {'detail': str(exc)},
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
+    except ValidationError:
+        log.exception('historical_dispensaciones: validación pydantic')
+        return Response(
+            {'detail': 'La respuesta del servicio externo no pudo interpretarse.'},
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
+    serializer = HistoricalDispensacionesResponseSerializer(instance=parsed)
+    return Response(serializer.data)
 
 
 @extend_schema(

--- a/core/apps/base/resources/ai/providers/anthropic.py
+++ b/core/apps/base/resources/ai/providers/anthropic.py
@@ -37,7 +37,7 @@ class AnthropicStructuredVisionProvider(AnthropicProvider):
     Streaming avoids SDK non-streaming timeouts on large vision + JSON responses.
     """
         
-    @retry(retry=retry_if_exception_type(ValidationError), stop=stop_after_attempt(5), reraise=True)
+    @retry(retry=retry_if_exception_type(ValidationError), stop=stop_after_attempt(2), reraise=True)
     def run_vision_json_schema(
         self, request: VisionStructuredRequest
     ) -> VisionStructuredResult:
@@ -93,7 +93,8 @@ class AnthropicStructuredVisionProvider(AnthropicProvider):
             raise ValueError('El modelo devolvió JSON inválido.') from e
         except ValidationError as e:
             log.error(f'Json inesperado por parte del LLM: {e}')
-            raise
+            missing_fields = ' '.join([error.get('loc', ("",""))[0] for error in e.errors()])
+            raise ValueError(f'Los siguientes campos no fueron encontrados al leerse la foto: {missing_fields}')
         except Exception as e:
             log.error(f'Error inesperado: {e}')
             raise ValueError(e)

--- a/core/apps/base/resources/ai/providers/anthropic.py
+++ b/core/apps/base/resources/ai/providers/anthropic.py
@@ -10,7 +10,9 @@ from typing import Any
 
 import anthropic
 from django.conf import settings
+from pydantic import ValidationError
 from tenacity import retry
+from tenacity.stop import stop_after_attempt
 
 from core.apps.base.resources.ai.providers.base import (
     LLMUsageMeta,
@@ -36,6 +38,7 @@ class AnthropicStructuredVisionProvider(AnthropicProvider):
     Streaming avoids SDK non-streaming timeouts on large vision + JSON responses.
     """
         
+    @retry(retry=retry.retry_if_exception_type(ValidationError), stop=stop_after_attempt(5), reraise=True)
     def run_vision_json_schema(
         self, request: VisionStructuredRequest
     ) -> VisionStructuredResult:
@@ -89,9 +92,12 @@ class AnthropicStructuredVisionProvider(AnthropicProvider):
         except json.JSONDecodeError as e:
             log.warning('Structured vision JSON parse failed: %s', e)
             raise ValueError('El modelo devolvió JSON inválido.') from e
+        except ValidationError as e:
+            log.error(f'Json inesperado por parte del LLM: {e}')
+            raise
         except Exception as e:
-            log.error('Json inesperado por parte del LLM: %s', e)
-            raise ValueError('El modelo devolvió JSON inválido o información incompleta.') from e
+            log.error(f'Error inesperado: {e}')
+            raise ValueError(e)
 
         usage = anthropic_usage_meta(request.model_id, response.usage)
         return VisionStructuredResult(prescription_ocr_result=prescription_ocr_result, usage=usage)

--- a/core/apps/base/resources/ai/providers/anthropic.py
+++ b/core/apps/base/resources/ai/providers/anthropic.py
@@ -11,8 +11,7 @@ from typing import Any
 import anthropic
 from django.conf import settings
 from pydantic import ValidationError
-from tenacity import retry
-from tenacity.stop import stop_after_attempt
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
 from core.apps.base.resources.ai.providers.base import (
     LLMUsageMeta,
@@ -38,7 +37,7 @@ class AnthropicStructuredVisionProvider(AnthropicProvider):
     Streaming avoids SDK non-streaming timeouts on large vision + JSON responses.
     """
         
-    @retry(retry=retry.retry_if_exception_type(ValidationError), stop=stop_after_attempt(5), reraise=True)
+    @retry(retry=retry_if_exception_type(ValidationError), stop=stop_after_attempt(5), reraise=True)
     def run_vision_json_schema(
         self, request: VisionStructuredRequest
     ) -> VisionStructuredResult:

--- a/core/apps/base/resources/ai/providers/base.py
+++ b/core/apps/base/resources/ai/providers/base.py
@@ -118,7 +118,7 @@ class Articulo(BaseModel):
             and self.Cantidad.Formulada.Valor is not None
         ):
             _, extra = divmod(self.Cantidad.Formulada.Valor, (self.Duracion.ValorEnDias / 30))
-            monthly_rounded = round({self.Cantidad.Formulada.Valor / (self.Duracion.ValorEnDias / 30)})
+            monthly_rounded = round(self.Cantidad.Formulada.Valor / (self.Duracion.ValorEnDias / 30))
             if extra:
                 logger.error("Cantidad dispensada inválida", extra={
                     "explicación": f"La cantidad formulada de {self.Cantidad.Formulada.Valor} es para {self.Duracion.ValorEnDias} días. \

--- a/core/apps/base/resources/ai/providers/base.py
+++ b/core/apps/base/resources/ai/providers/base.py
@@ -154,6 +154,18 @@ class PrescriptionOCRResult(BaseModel):
     def normalize_ips(cls, v: str) -> str:
         return remove_accents(v.upper().strip())
 
+    
+    @field_validator('TipoDocumentoPaciente', mode='after')
+    @classmethod
+    def normalize_ips(cls, v: str) -> str:
+        tipo_documento = remove_accents(v.upper().strip())
+        match tipo_documento:
+            case 'cedula de ciudadania':
+                return "CC"
+            case _:
+                return tipo_documento
+
+
     @property
     def diagnostico_principal(self) -> str:
         return ' '.join(self.DiagnosticoPrincipal.__dict__.values())

--- a/core/apps/base/resources/ai/providers/base.py
+++ b/core/apps/base/resources/ai/providers/base.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any
 import anthropic
 from pydantic import BaseModel, BeforeValidator, PlainSerializer, field_validator, model_validator
 
-from core import settings
+from core.settings import ANTHROPIC_API_KEY, logger
 from core.apps.base.resources.tools import remove_accents
 
 
@@ -117,7 +117,14 @@ class Articulo(BaseModel):
             and self.Cantidad.Formulada is not None
             and self.Cantidad.Formulada.Valor is not None
         ):
-            monthly = int(self.Cantidad.Formulada.Valor / (self.Duracion.ValorEnDias / 30))
+            monthly, extra = divmod(self.Cantidad.Formulada.Valor, (self.Duracion.ValorEnDias / 30))
+            if extra:
+                logger.error("Cantidad dispensada inválida", extra={
+                    "explicación": f"La cantidad formulada de {self.Cantidad.Formulada.Valor} es para {self.Duracion.ValorEnDias} días. \
+                    Entonces el valor para 30 días es de {self.Cantidad.Formulada.Valor / (self.Duracion.ValorEnDias / 30)}",
+                    **self.Cantidad.model_dump(),
+                    **self.Duracion.model_dump(),
+                })
             self.Cantidad.Dispensada = CantidadDetalle(Valor=monthly, Descripcion='Por mes')
         else:
             self.Cantidad.Dispensada = self.Cantidad.Formulada.model_copy()
@@ -157,7 +164,7 @@ class PrescriptionOCRResult(BaseModel):
     
     @field_validator('TipoDocumentoPaciente', mode='after')
     @classmethod
-    def normalize_ips(cls, v: str) -> str:
+    def normalize_tipodocumentopaciente(cls, v: str) -> str:
         tipo_documento = remove_accents(v.upper().strip())
         match tipo_documento:
             case 'cedula de ciudadania':
@@ -206,6 +213,6 @@ class AnthropicProvider:
     """Base class for Anthropic SDK adapters."""
 
     def __init__(self, *, api_key: str | None = None, max_retries: int = 3) -> None:
-        if not (key := settings.ANTHROPIC_API_KEY):
+        if not (key := ANTHROPIC_API_KEY):
             raise ValueError('ANTHROPIC_API_KEY no está configurada.')
         self.client = anthropic.Anthropic(api_key=key, max_retries=max_retries)

--- a/core/apps/base/resources/ai/providers/base.py
+++ b/core/apps/base/resources/ai/providers/base.py
@@ -117,7 +117,8 @@ class Articulo(BaseModel):
             and self.Cantidad.Formulada is not None
             and self.Cantidad.Formulada.Valor is not None
         ):
-            monthly, extra = divmod(self.Cantidad.Formulada.Valor, (self.Duracion.ValorEnDias / 30))
+            _, extra = divmod(self.Cantidad.Formulada.Valor, (self.Duracion.ValorEnDias / 30))
+            monthly_rounded = round({self.Cantidad.Formulada.Valor / (self.Duracion.ValorEnDias / 30)})
             if extra:
                 logger.error("Cantidad dispensada inválida", extra={
                     "explicación": f"La cantidad formulada de {self.Cantidad.Formulada.Valor} es para {self.Duracion.ValorEnDias} días. \
@@ -125,7 +126,7 @@ class Articulo(BaseModel):
                     **self.Cantidad.model_dump(),
                     **self.Duracion.model_dump(),
                 })
-            self.Cantidad.Dispensada = CantidadDetalle(Valor=monthly, Descripcion='Por mes')
+            self.Cantidad.Dispensada = CantidadDetalle(Valor=monthly_rounded, Descripcion='Por mes')
         else:
             self.Cantidad.Dispensada = self.Cantidad.Formulada.model_copy()
         return self

--- a/core/apps/base/resources/medicar.py
+++ b/core/apps/base/resources/medicar.py
@@ -249,7 +249,7 @@ def validate_historico_dispensados(raw: object) -> HistoricoDispensados:
     :raises pydantic.ValidationError: if list items do not match the schema.
     """
     if not isinstance(raw, list):
-        msg = "La respuesta de historico dispensaciones debe ser una lista; se recibió {raw}"
+        msg = f"La respuesta de historico dispensaciones debe ser una lista; se recibió {raw}"
         raise TypeError(msg)
     return HistoricoDispensados.model_validate(raw)
 

--- a/core/apps/base/resources/medicar.py
+++ b/core/apps/base/resources/medicar.py
@@ -1,5 +1,8 @@
 import re
 
+from django.http import Http404
+from rest_framework.exceptions import NotFound
+
 from core.apps.base.resources.api_calls import call_api_medicar
 from core.settings import logger as log
 from pydantic import BaseModel, ConfigDict, RootModel, field_validator
@@ -249,6 +252,9 @@ def validate_historico_dispensados(raw: object) -> HistoricoDispensados:
     :raises pydantic.ValidationError: if list items do not match the schema.
     """
     if not isinstance(raw, list):
+        if 'error' in raw and 'No se han encontrado' in raw['error']:
+            # Esto sucede cuando no se le ha dispensado nunca
+            raise NotFound(detail="Usuario no encontrado en medicar", code=404)
         msg = f"La respuesta de historico dispensaciones debe ser una lista; se recibió {raw}"
         raise TypeError(msg)
     return HistoricoDispensados.model_validate(raw)

--- a/core/apps/base/resources/medicar.py
+++ b/core/apps/base/resources/medicar.py
@@ -1,7 +1,8 @@
 import re
+
 from core.apps.base.resources.api_calls import call_api_medicar
 from core.settings import logger as log
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, RootModel, field_validator
 
 
 def obtener_datos_formula(num_aut: int, nit: str = '901543211') -> dict:
@@ -112,6 +113,149 @@ def obtener_inventario(centro: int) -> list[dict]:
     if isinstance(resp, list):
         return resp
     return []
+
+def obtener_historico_dispensados_usuario(documento: str, dias_dispensacion: int = 25) -> list:
+    """Busca el histórico de dispensados para un determinado usuario en los ultimos 25 días."""
+    return call_api_medicar({
+        "NumeroDocumento": documento,
+        "DiasDispensacion": dias_dispensacion,
+        "PendientesActivos": True,
+        "IdConvenio": 0
+    }, 'historico-dispensaciones/client/6')
+
+
+CodMolType = int | str
+
+
+class HistoricoDispensacionItem(BaseModel):
+    """One dispensación line inside Articulos[].Dispensaciones[]."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    CantidadDispensada: int | float = 0
+    FecDisp: str | None = None
+
+    @field_validator("CantidadDispensada", mode="before")
+    @classmethod
+    def coerce_cantidad(cls, v: object) -> int | float:
+        if v is None:
+            return 0
+        if isinstance(v, bool):
+            return int(v)
+        if isinstance(v, int | float):
+            return v
+        try:
+            return int(str(v).strip())
+        except (TypeError, ValueError):
+            return 0
+
+
+class HistoricoArticuloMedicar(BaseModel):
+    """Articulo node under SSCs[].Articulos[]."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    CodMol: CodMolType
+    Plu: str | None = None
+    Descripcion: str | None = None
+    CantidadSolicitada: int | float | None = None
+    CantidadPendiente: int | float | None = None
+    InventarioMoleculaCentro: int | float | None = None
+    TotalPendienteMoleculaCentro: int | float | None = None
+    TransitoMoleculaCentro: int | float | None = None
+    Dispensaciones: list[HistoricoDispensacionItem] = []
+
+
+class HistoricoSSCMedicar(BaseModel):
+    """SSC node under top-level SSCs[]."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    SSC: int | None = None
+    SubPlan: str | None = None
+    Autorizacion: str | None = None
+    MIPRES: str | None = None
+    FecSol: str | None = None
+    Centro: str | None = None
+    NombCaf: str | None = None
+    Articulos: list[HistoricoArticuloMedicar] = []
+
+
+class HistoricoDispensado(BaseModel):
+    """
+    One affiliate record from historico-dispensaciones (Medicar).
+
+    Use ``HistoricoDispensado(**resp)`` when ``resp`` is a single dict from the API list.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    TipoDoc: str | None = None
+    NumeroDocumento: str | None = None
+    Afiliado: str | None = None
+    PendientesActivos: bool | None = None
+    SSCs: list[HistoricoSSCMedicar] = []
+
+    def sum_cantidad_dispensada_por_cod_mol(self, cod_mol: CodMolType) -> int:
+        """Sum CantidadDispensada for this afiliado row, all SSCs/articulos matching CodMol."""
+        return sum_cantidad_dispensada_cod_mol_afiliado(self, cod_mol)
+
+
+class HistoricoDispensados(RootModel[list[HistoricoDispensado]]):
+    """
+    Validates the full Medicar list response.
+
+    ``HistoricoDispensados.model_validate(raw_list)`` when ``raw_list`` is the API body.
+    """
+
+    root: list[HistoricoDispensado]
+
+    def sum_cantidad_dispensada_por_cod_mol(self, cod_mol: CodMolType) -> int:
+        """Sum CantidadDispensada across all afiliado records for the given CodMol."""
+        return sum(
+            rec.sum_cantidad_dispensada_por_cod_mol(cod_mol) for rec in self.root
+        )
+
+    def model_dump_list(self) -> list[dict]:
+        """Serialize back to plain dicts with Medicar-like keys for API consumers."""
+        return [r.model_dump(mode="json") for r in self.root]
+
+
+def _cod_mol_equals(a: CodMolType, b: CodMolType) -> bool:
+    return str(a).strip() == str(b).strip()
+
+
+def sum_cantidad_dispensada_cod_mol_afiliado(
+    afiliado: HistoricoDispensado, cod_mol: CodMolType
+) -> int:
+    total = 0
+    for ssc in afiliado.SSCs:
+        for art in ssc.Articulos:
+            if not _cod_mol_equals(art.CodMol, cod_mol):
+                continue
+            for disp in art.Dispensaciones:
+                try:
+                    total += int(float(disp.CantidadDispensada))
+                except (TypeError, ValueError):
+                    continue
+    return total
+
+
+def validate_historico_dispensados(raw: object) -> HistoricoDispensados:
+    """
+    Parse Medicar historico-dispensaciones response.
+
+    :raises TypeError: if ``raw`` is not a list.
+    :raises pydantic.ValidationError: if list items do not match the schema.
+    """
+    if not isinstance(raw, list):
+        msg = (
+            "La respuesta de historico dispensaciones debe ser una lista; "
+            f"se recibió {type(raw).__name__}"
+        )
+        raise TypeError(msg)
+    return HistoricoDispensados.model_validate(raw)
+
 
 class EpsSchema(BaseModel):
     nitEps: str

--- a/core/apps/base/resources/medicar.py
+++ b/core/apps/base/resources/medicar.py
@@ -249,10 +249,7 @@ def validate_historico_dispensados(raw: object) -> HistoricoDispensados:
     :raises pydantic.ValidationError: if list items do not match the schema.
     """
     if not isinstance(raw, list):
-        msg = (
-            "La respuesta de historico dispensaciones debe ser una lista; "
-            f"se recibió {type(raw).__name__}"
-        )
+        msg = "La respuesta de historico dispensaciones debe ser una lista; se recibió {raw}"
         raise TypeError(msg)
     return HistoricoDispensados.model_validate(raw)
 

--- a/core/apps/base/resources/prescription_ocr/goals/barra_lookup.py
+++ b/core/apps/base/resources/prescription_ocr/goals/barra_lookup.py
@@ -27,10 +27,9 @@ Active ingredient stems (strip salt descriptors like "clorhidrato de", "hidroclo
 - Price-regulated (regulado = 'S') — indicates official recognition in the formulary
 - Most recent purchase activity (ultima_compra) — signals real inventory movement
 Complete commercial identity — valid barcode, known brand (marca ≠ 'NA') Present the winning record with a concise justification of why it outscored the others.
-Do not return the entire record, only the "barra" value which is usually an integer with more than 5 ditigs.
+Do not return the entire record, only the "barra" value which is usually an integer with between 5 up to 20 ditigs.
 Return the value of the "barra" and no more than that. Avoid explanations and additional information besides than "barra"
 """
-
 
 def build_barra_lookup_user_prompt(*, nombre_articulo: str) -> str:
     safe = (nombre_articulo or '').strip()

--- a/core/apps/base/resources/prescription_ocr/service.py
+++ b/core/apps/base/resources/prescription_ocr/service.py
@@ -156,8 +156,8 @@ class PrescriptionOCRService:
 
             txn.result = prescription_ocr_result.model_dump()
             if (txn.result['TipoDocumentoPaciente'] and txn.result['TipoDocumentoPaciente'] != radicacion.tipo_documento_paciente) or (txn.result['NumeroDocumentoPaciente'] and txn.result['NumeroDocumentoPaciente'] != radicacion.numero_documento_paciente):
-                logger.error(f"{radicacion.numero_autorizacion} Documento escaneado no coincide con documento de radicación", 
-                extra={"OCR Result": f"Tipo Documento {txn.result['TipoDocumentoPaciente']!r}, Documento {txn.result['NumeroDocumentoPaciente']}",
+                logger.error(f"Documento escaneado no coincide con documento de radicación", 
+                extra={"numero_autorizacion": radicacion.numero_autorizacion, "convenio": radicacion.convenio, "OCR Result": f"Tipo Documento {txn.result['TipoDocumentoPaciente']!r}, Documento {txn.result['NumeroDocumentoPaciente']}",
                 "Radicación":f"Tipo Documento {radicacion.tipo_documento_paciente!r}, Documento {radicacion.numero_documento_paciente}"}
                 )
             

--- a/core/apps/base/resources/prescription_ocr/service.py
+++ b/core/apps/base/resources/prescription_ocr/service.py
@@ -36,6 +36,7 @@ class PrescriptionOCRRunOutcome:
     transaction: PrescriptionOCRTransaction
     cached: bool
     error: Literal['drive', 'llm'] | None = None
+    reason: str = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -152,6 +153,7 @@ class PrescriptionOCRService:
                     transaction=txn,
                     cached=False,
                     error='llm',
+                    reason=txn.error_message
                 )
 
             txn.result = prescription_ocr_result.model_dump()

--- a/core/apps/base/resources/prescription_ocr/service.py
+++ b/core/apps/base/resources/prescription_ocr/service.py
@@ -155,8 +155,11 @@ class PrescriptionOCRService:
                 )
 
             txn.result = prescription_ocr_result.model_dump()
-            if txn.result['TipoDocumentoPaciente'] != radicacion.tipo_documento_paciente or txn.result['NumeroDocumentoPaciente'] != radicacion.numero_documento_paciente:
-                logger.error(f"{radicacion.numero_autorizacion} Documento escaneado no coincide con documento de radicación")
+            if (txn.result['TipoDocumentoPaciente'] and txn.result['TipoDocumentoPaciente'] != radicacion.tipo_documento_paciente) or (txn.result['NumeroDocumentoPaciente'] and txn.result['NumeroDocumentoPaciente'] != radicacion.numero_documento_paciente):
+                logger.error(f"{radicacion.numero_autorizacion} Documento escaneado no coincide con documento de radicación", 
+                extra={"OCR Result": f"Tipo Documento {txn.result['TipoDocumentoPaciente']!r}, Documento {txn.result['NumeroDocumentoPaciente']}",
+                "Radicación":f"Tipo Documento {radicacion.tipo_documento_paciente!r}, Documento {radicacion.numero_documento_paciente}"}
+                )
             
             txn.status = Status.COMPLETED.value
             txn.model_id = self._model_id

--- a/core/apps/home/templates/pages/radicacion_detail.html
+++ b/core/apps/home/templates/pages/radicacion_detail.html
@@ -1398,6 +1398,11 @@
     min-width: 4rem;
   }
 
+  .ocr-historico-cell--pending {
+    min-width: 2.75rem;
+    text-align: right;
+  }
+
   .ocr-inline-spinner-wrap {
     display: inline-flex;
     align-items: center;
@@ -2316,6 +2321,7 @@
   const API_RUN = '/api/v1/prescription-ocr/';
   const API_DISCARD = '/api/v1/prescription-ocr/discard/';
   const API_BARRA_POLL_BASE = '/api/v1/prescription-ocr/barra/';
+  const API_HISTORICAL_DISPENSATIONS_BASE = '/api/v1/historical-dispensations/';
   const BARRA_POLL_INTERVAL_MS = 10000;
   const BARRA_POLL_MAX_ATTEMPTS = 30;
   const currentDriveUrl = btn.getAttribute('data-drive-url') || '';
@@ -2328,6 +2334,8 @@
   let lastResultForJsonCopy = {};
   let lastJsonBlockPayload = {};
   let lastMedicationIndexByArticleNumero = {};
+  let lastOcrNumeroDocumentoPaciente = '';
+  let historicalDispByDocumento = Object.create(null);
 
   ocrSection.addEventListener('click', function(e) {
     const jsonCopyBtn = e.target.closest('#ocrJsonCopyBtn');
@@ -2748,7 +2756,7 @@
     }
   }
 
-  function pollBarraJobOnce(jobId, articleNombre, ips, attempt) {
+  function pollBarraJobOnce(jobId, articleNombre, ips, attempt, articleNumero) {
     // console.log("About to pollBarraJobOnce", jobId, articleNombre, ips, attempt);
     attempt = attempt || 0;
     if (attempt >= BARRA_POLL_MAX_ATTEMPTS) {
@@ -2759,6 +2767,9 @@
         sap_article: null,
       };
       updateBarraJobDom(jobId, timeoutData);
+      if (articleNumero != null && articleNumero !== '') {
+        restoreUltDispFromOcr(String(articleNumero));
+      }
       return Promise.resolve(timeoutData);
     }
     var barraPollUrl = API_BARRA_POLL_BASE + jobId + '/';
@@ -2783,11 +2794,35 @@
         if (data.status === 'completado' || data.status === 'fallido') {
           updateBarraJobDom(jobId, data);
           appendBarraJobMetaRow(data);
+          var an =
+            data.article_numero != null
+              ? String(data.article_numero)
+              : articleNumero != null
+                ? String(articleNumero)
+                : '';
+          if (
+            data.status === 'completado' &&
+            data.sap_article &&
+            data.sap_article.molecula_id != null &&
+            String(data.sap_article.molecula_id).trim() !== ''
+          ) {
+            applyHistoricalDispForRow(an, String(data.sap_article.molecula_id));
+          } else {
+            restoreUltDispFromOcr(an);
+          }
           return data;
         }
         return new Promise(function(resolve) {
           setTimeout(function() {
-            resolve(pollBarraJobOnce(jobId, articleNombre, ips, attempt + 1));
+            resolve(
+              pollBarraJobOnce(
+                jobId,
+                articleNombre,
+                ips,
+                attempt + 1,
+                articleNumero
+              )
+            );
           }, BARRA_POLL_INTERVAL_MS);
         });
       })
@@ -2795,7 +2830,15 @@
         console.error('Error polling barra job', jobId, articleNombre, ips, attempt,error);
         return new Promise(function(resolve) {
           setTimeout(function() {
-            resolve(pollBarraJobOnce(jobId, articleNombre, ips, attempt + 1));
+            resolve(
+              pollBarraJobOnce(
+                jobId,
+                articleNombre,
+                ips,
+                attempt + 1,
+                articleNumero
+              )
+            );
           }, BARRA_POLL_INTERVAL_MS);
         });
       });
@@ -2811,7 +2854,13 @@
         return j && j.job_id && j.status !== 'fallido';
       })
       .map(function(j) {
-        return pollBarraJobOnce(j.job_id, j.article_nombre, normalizedIps, 0);
+        return pollBarraJobOnce(
+          j.job_id,
+          j.article_nombre,
+          normalizedIps,
+          0,
+          j.article_numero
+        );
       });
 
     Promise.all(polls).then(function(results) {
@@ -2841,13 +2890,125 @@
     );
   }
 
+  function resetHistoricalDispCache() {
+    historicalDispByDocumento = Object.create(null);
+  }
+
+  function fetchHistoricalDispensacionesList(documento) {
+    var doc = String(documento || '').trim();
+    if (!doc) return Promise.resolve([]);
+    if (historicalDispByDocumento[doc] !== undefined) {
+      return historicalDispByDocumento[doc];
+    }
+    var url =
+      API_HISTORICAL_DISPENSATIONS_BASE + encodeURIComponent(doc) + '/';
+    historicalDispByDocumento[doc] = fetch(url, {
+      credentials: 'same-origin',
+      headers: {
+        Accept: 'application/json',
+        'X-CSRFToken': getCsrfToken(),
+      },
+    })
+      .then(function(res) {
+        if (!res.ok) return [];
+        return res.json();
+      })
+      .then(function(body) {
+        return Array.isArray(body) ? body : [];
+      })
+      .catch(function(err) {
+        console.error('Error historical-dispensations', doc, err);
+        return [];
+      });
+    return historicalDispByDocumento[doc];
+  }
+
+  function sumCantidadDispensadaByCodMol(historicalList, codMol) {
+    var target = String(codMol);
+    var sum = 0;
+    (historicalList || []).forEach(function(aff) {
+      (aff.SSCs || []).forEach(function(ssc) {
+        (ssc.Articulos || []).forEach(function(art) {
+          if (String(art.CodMol) !== target) return;
+          (art.Dispensaciones || []).forEach(function(d) {
+            var n = parseFloat(d.CantidadDispensada);
+            if (isFinite(n)) sum += n;
+          });
+        });
+      });
+    });
+    return Math.round(sum);
+  }
+
+  function updateUltDispCell(articleNumero, text) {
+    if (!modalContent || articleNumero == null || articleNumero === '') return;
+    var el = modalContent.querySelector(
+      '[data-ocr-historico-article-numero="' + String(articleNumero) + '"]'
+    );
+    if (!el) return;
+    el.classList.remove('ocr-historico-cell--pending');
+    el.textContent = text === undefined || text === null ? '' : String(text);
+  }
+
+  function restoreUltDispFromOcr(articleNumero) {
+    if (!modalContent || articleNumero == null || articleNumero === '') return;
+    var an = String(articleNumero);
+    var arts = (lastResultForJsonCopy && lastResultForJsonCopy.Articulos) || [];
+    var v = '';
+    for (var i = 0; i < arts.length; i++) {
+      var row = arts[i];
+      if (!row || String(row.Numero) !== an) continue;
+      if (
+        row.Cantidad &&
+        row.Cantidad.Historico &&
+        row.Cantidad.Historico.Valor != null
+      ) {
+        v = String(row.Cantidad.Historico.Valor);
+      }
+      break;
+    }
+    updateUltDispCell(an, v !== '' ? v : '—');
+  }
+
+  function applyHistoricalDispForRow(articleNumero, codMol) {
+    if (!modalContent || articleNumero == null || articleNumero === '') return;
+    var an = String(articleNumero);
+    var doc = String(lastOcrNumeroDocumentoPaciente || '').trim();
+    if (!doc || codMol == null || String(codMol).trim() === '') {
+      restoreUltDispFromOcr(an);
+      return;
+    }
+    fetchHistoricalDispensacionesList(doc).then(function(list) {
+      var total = sumCantidadDispensadaByCodMol(list, codMol);
+      updateUltDispCell(an, String(total));
+    });
+  }
+
+  function scheduleInitialHistoricalDisp(barraJobs) {
+    (barraJobs || []).forEach(function(j) {
+      if (
+        !j ||
+        j.status !== 'completado' ||
+        !j.sap_article ||
+        j.sap_article.molecula_id == null ||
+        String(j.sap_article.molecula_id).trim() === ''
+      ) {
+        return;
+      }
+      applyHistoricalDispForRow(
+        j.article_numero != null ? String(j.article_numero) : '',
+        String(j.sap_article.molecula_id)
+      );
+    });
+  }
+
   function buildArticulos(arts, barraJobsList) {
     if (!arts || !arts.length) return '';
     var byJob = indexBarraJobsByArticleNumero(barraJobsList);
     const head =
-      '<thead><tr><th>#</th><th>Nombre</th><th>Cant. Mes' +
+      '<thead><tr><th>#</th><th>Nombre</th><th>Cant.<br>Mes' +
       createTooltip('?', 'Esta es la cantidad equivalente a un mes') +
-      '</th><th>Ult. Disp' +
+      '</th><th>Ult.<br>Disp' +
       createTooltip('?', 'Cantidad dispensada en los últimos 25 días') +
       '</th></tr></thead>';
     const bodyRows = arts.map(function(a) {
@@ -2889,6 +3050,41 @@
         jobStatus !== 'fallido'
       );
 
+      var barraFailedHistorico = job && job.status === 'fallido';
+      var barraCompleteWithMol = !!(
+        job &&
+        job.status === 'completado' &&
+        job.sap_article &&
+        job.sap_article.molecula_id != null &&
+        String(job.sap_article.molecula_id).trim() !== ''
+      );
+      var jobRunningHistorico = !!(
+        jobId &&
+        jobStatus !== 'completado' &&
+        jobStatus !== 'fallido'
+      );
+      var showHistoricoSpinner = !!(
+        jobId &&
+        !barraFailedHistorico &&
+        (jobRunningHistorico || barraCompleteWithMol)
+      );
+
+      var historicoTdClass = 'ocr-historico-val';
+      var historicoCellInner = '';
+      if (!jobId) {
+        historicoCellInner = escapeHtml(historico);
+      } else if (barraFailedHistorico) {
+        historicoCellInner = escapeHtml(historico !== '' ? historico : '—');
+      } else if (showHistoricoSpinner) {
+        historicoTdClass += ' ocr-historico-cell--pending';
+        historicoCellInner =
+          '<span class="ocr-inline-spinner-wrap" aria-busy="true">' +
+          '<span class="ocr-inline-spinner"></span>' +
+          '<span class="sr-only">Cargando última dispensación</span></span>';
+      } else {
+        historicoCellInner = escapeHtml(historico !== '' ? historico : '—');
+      }
+
       var secondaryInfo = '';
       if (formaFarm || frecuencia) {
         var parts = [];
@@ -2918,7 +3114,14 @@
       }
       row1 +=
         '</td><td>' + escapeHtml(cantidad) +
-        '</td><td>' + escapeHtml(historico) +
+        '</td><td class="' +
+        historicoTdClass +
+        '"' +
+        (numero
+          ? ' data-ocr-historico-article-numero="' + escapeHtml(numero) + '"'
+          : '') +
+        '>' +
+        historicoCellInner +
         '</td></tr>';
 
       var niHtml;
@@ -2963,7 +3166,12 @@
 
   function renderResult(payload) {
     lastResultForJsonCopy = payload.result || {};
+    resetHistoricalDispCache();
     const r = lastResultForJsonCopy;
+    lastOcrNumeroDocumentoPaciente =
+      r.NumeroDocumentoPaciente != null
+        ? String(r.NumeroDocumentoPaciente).trim()
+        : '';
     lastMedicationIndexByArticleNumero = indexMedicamentosByArticleNumero(r.Articulos || []);
     
     try {
@@ -3011,6 +3219,7 @@
     recalculateOcrMetaTotals();
     
     scheduleBarraPolling(payload.barra_jobs || [], payload.result.IPS);
+    scheduleInitialHistoricalDisp(payload.barra_jobs || []);
 
     lastTransactionId = payload.transaction_id;
     discardBtn.hidden = !payload.transaction_id;

--- a/core/apps/home/templates/pages/radicacion_detail.html
+++ b/core/apps/home/templates/pages/radicacion_detail.html
@@ -1400,7 +1400,7 @@
 
   .ocr-historico-cell--pending {
     min-width: 2.75rem;
-    text-align: right;
+    text-align: center;
   }
 
   .ocr-inline-spinner-wrap {
@@ -1834,7 +1834,7 @@
               <div class="patient-compact-col">
                 <span class="patient-compact-label">Documento</span>
                 <span class="patient-compact-value">
-                  <span class="copy-value">{{ rad.paciente_cc|default:"--" }}</span>
+                  <span class="copy-value" id="numero_documento_paciente" solo_documento="{{rad.numero_documento_paciente}}">{{ rad.tipo_documento_paciente|default:"--" }}{{ rad.numero_documento_paciente|default:"--" }}</span>
                   {% if rad.paciente_cc %}
                   <button type="button" class="copy-btn" data-copy-text="{{ rad.paciente_cc }}" aria-label="Copiar documento">
                     <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -3153,7 +3153,7 @@
         (jobRunningHistorico || barraCompleteWithMol)
       );
 
-      var historicoTdClass = 'ocr-historico-val';
+      var historicoTdClass = 'text-center ocr-historico-val';
       var historicoCellInner = '';
       if (!jobId) {
         historicoCellInner = escapeHtml(historico);
@@ -3215,7 +3215,7 @@
           '</div>';
       }
       row1 +=
-        '</td><td>' + escapeHtml(cantidad) +
+        "</td><td class='text-center'>" + escapeHtml(cantidad) +
         '</td><td class="' + historicoTdClass + '"' +
         (numero ? ' data-ocr-historico-article-numero="' + escapeHtml(numero) + '"' : '') +
         '>' + historicoCellInner +
@@ -3269,9 +3269,10 @@
     lastResultForJsonCopy = payload.result || {};
     resetHistoricalDispCache();
     const r = lastResultForJsonCopy;
+    var numero_documento_paciente = document.getElementById('numero_documento_paciente')
     lastOcrNumeroDocumentoPaciente =
-      r.NumeroDocumentoPaciente != null
-        ? String(r.NumeroDocumentoPaciente).trim()
+      numero_documento_paciente != null
+        ? String(numero_documento_paciente.getAttribute('solo_documento')).trim()
         : '';
     lastMedicationIndexByArticleNumero = indexMedicamentosByArticleNumero(r.Articulos || []);
     

--- a/core/apps/home/templates/pages/radicacion_detail.html
+++ b/core/apps/home/templates/pages/radicacion_detail.html
@@ -2924,20 +2924,32 @@
   }
 
   function sumCantidadDispensadaByCodMol(historicalList, codMol) {
+    /**
+     * Suma por molécula (CodMol): total dispensado más total pendiente.
+     * Recorre el JSON de `/historical-dispensations` (SSC → Articulos) y coincide
+     * `CodMol` con `codMol`. Acumula `CantidadDispensada` de cada `Dispensaciones`
+     * y `CantidadPendiente` por línea de artículo; devuelve ambos sumandos redondeados.
+     * @param {Array<Object>} historicalList Lista de registros tipo afiliado (respuesta Medicar).
+     * @param {number|string} codMol Identificador de molécula (equiv. molecula_id SAP).
+     * @returns {number} Math.round(sumDispensada) + Math.round(sumPendiente)
+     */
     var target = String(codMol);
-    var sum = 0;
+    var sumDispensada = 0;
+    var sumPendiente = 0;
     (historicalList || []).forEach(function(aff) {
       (aff.SSCs || []).forEach(function(ssc) {
         (ssc.Articulos || []).forEach(function(art) {
           if (String(art.CodMol) !== target) return;
+          var p = parseFloat(art.CantidadPendiente);
+          if (isFinite(p)) sumPendiente += p;
           (art.Dispensaciones || []).forEach(function(d) {
             var n = parseFloat(d.CantidadDispensada);
-            if (isFinite(n)) sum += n;
+            if (isFinite(n)) sumDispensada += n;
           });
         });
       });
     });
-    return Math.round(sum);
+    return Math.round(sumDispensada) + Math.round(sumPendiente);
   }
 
   function updateUltDispCell(articleNumero, text) {

--- a/core/apps/home/templates/pages/radicacion_detail.html
+++ b/core/apps/home/templates/pages/radicacion_detail.html
@@ -2941,16 +2941,70 @@
   }
 
   function updateUltDispCell(articleNumero, text) {
+    /*
+    Finds the Ult. Disp <td> with data-ocr-historico-article-numero, 
+      clears the pending/historico spinner styling, 
+      and sets the cell textContent to the string you pass in (typically the dispensada total).
+    Also triggers updateCantDispCell so the derived Cant. Disp. column stays in sync.
+    */
     if (!modalContent || articleNumero == null || articleNumero === '') return;
+    var an = String(articleNumero);
     var el = modalContent.querySelector(
-      '[data-ocr-historico-article-numero="' + String(articleNumero) + '"]'
+      '[data-ocr-historico-article-numero="' + an + '"]'
     );
     if (!el) return;
     el.classList.remove('ocr-historico-cell--pending');
     el.textContent = text === undefined || text === null ? '' : String(text);
+    updateCantDispCell(an, parseFloat(String(text || '')));
+  }
+
+  function updateJsonBlockCantidadDispensada(articleNumero, cantDisp) {
+    var medicamentos =
+      lastJsonBlockPayload &&
+      lastJsonBlockPayload.formula &&
+      Array.isArray(lastJsonBlockPayload.formula.medicamentos)
+        ? lastJsonBlockPayload.formula.medicamentos
+        : null;
+    if (!medicamentos) return;
+    var numero = parseInt(articleNumero, 10);
+    if (!isFinite(numero)) return;
+    var mappedIndex = lastMedicationIndexByArticleNumero[String(numero)];
+    var medIndex = mappedIndex != null ? mappedIndex : numero - 1;
+    var med = medicamentos[medIndex];
+    if (!med) return;
+    med.cantidad_dispensada = cantDisp;
+    refreshJsonBlockPayload(lastJsonBlockPayload);
+  }
+
+  function updateCantDispCell(articleNumero, ultDispNum) {
+    /*
+    Computes max(0, cantMes - ultDispNum) using the data-ocr-cantmes attribute stored
+    on the Cant. Disp. cell, updates its textContent, and patches cantidad_dispensada
+    in the jsonBlock medicamento entry.
+    */
+    if (!modalContent || articleNumero == null || articleNumero === '') return;
+    var an = String(articleNumero);
+    var el = modalContent.querySelector('[data-ocr-cantdisp-article-numero="' + an + '"]');
+    if (!el) return;
+    el.classList.remove('ocr-historico-cell--pending');
+    var cantMesNum = parseFloat(el.getAttribute('data-ocr-cantmes') || '');
+    var cantDisp =
+      isFinite(cantMesNum) && isFinite(ultDispNum)
+        ? Math.max(0, cantMesNum - ultDispNum)
+        : null;
+    el.textContent = cantDisp !== null ? String(Math.round(cantDisp)) : '—';
+    if (cantDisp !== null) {
+      updateJsonBlockCantidadDispensada(an, Math.round(cantDisp));
+    }
   }
 
   function restoreUltDispFromOcr(articleNumero) {
+    /* 
+    Reads lastResultForJsonCopy.Articulos for that articleNumero and writes 
+      Cantidad.Historico.Valor into the Ult. Disp cell (via updateUltDispCell), 
+      or — when there is no OCR historico—used after failed barra, timeout, 
+      or complete barra without molecula_id
+    */
     if (!modalContent || articleNumero == null || articleNumero === '') return;
     var an = String(articleNumero);
     var arts = (lastResultForJsonCopy && lastResultForJsonCopy.Articulos) || [];
@@ -2971,6 +3025,12 @@
   }
 
   function applyHistoricalDispForRow(articleNumero, codMol) {
+    /*
+    For a given article row (articleNumero) and SAP molecula_id (CodMol), 
+    it asks the cached historical-dispensations list for the current patient document, 
+    computes the sum of CantidadDispensada for that CodMol, then fills the Ult. Disp cell. 
+    If there is no document or no CodMol, it falls back to restoreUltDispFromOcr
+    */
     if (!modalContent || articleNumero == null || articleNumero === '') return;
     var an = String(articleNumero);
     var doc = String(lastOcrNumeroDocumentoPaciente || '').trim();
@@ -2981,6 +3041,24 @@
     fetchHistoricalDispensacionesList(doc).then(function(list) {
       var total = sumCantidadDispensadaByCodMol(list, codMol);
       updateUltDispCell(an, String(total));
+    });
+  }
+
+  function scheduleInitialCantDisp(articles) {
+    /*
+    For articles whose Ult. Disp cell is already resolved at render time (no spinner),
+    compute and write Cant. Disp. immediately and patch the jsonBlock.
+    Articles with a pending historico spinner are handled later by updateUltDispCell.
+    */
+    if (!modalContent) return;
+    (articles || []).forEach(function(a) {
+      var numero = a.Numero != null ? String(a.Numero) : '';
+      if (!numero) return;
+      var ultDispEl = modalContent.querySelector(
+        '[data-ocr-historico-article-numero="' + numero + '"]'
+      );
+      if (!ultDispEl || ultDispEl.classList.contains('ocr-historico-cell--pending')) return;
+      updateCantDispCell(numero, parseFloat(ultDispEl.textContent));
     });
   }
 
@@ -3010,6 +3088,8 @@
       createTooltip('?', 'Esta es la cantidad equivalente a un mes') +
       '</th><th>Ult.<br>Disp' +
       createTooltip('?', 'Cantidad dispensada en los últimos 25 días') +
+      '</th><th>Cant.<br>Disp.' +
+      createTooltip('?', 'Cantidad a dispensar') +
       '</th></tr></thead>';
     const bodyRows = arts.map(function(a) {
       var numero = a.Numero != null ? String(a.Numero) : '';
@@ -3023,6 +3103,10 @@
         a.Cantidad && a.Cantidad.Historico && a.Cantidad.Historico.Valor != null
           ? String(a.Cantidad.Historico.Valor)
           : '';
+      var cantMesNum =
+        a.Cantidad && a.Cantidad.Dispensada && a.Cantidad.Dispensada.Valor != null
+          ? parseFloat(String(a.Cantidad.Dispensada.Valor))
+          : NaN;
       var nombreInterno =
         a.NombreInterno != null && a.NombreInterno !== ''
           ? String(a.NombreInterno)
@@ -3040,7 +3124,7 @@
           job.sap_article.descripcion != null &&
           job.sap_article.descripcion !== ''
         ) {
-          nombreInterno = String(job.sap_article.descripcion);
+          nombreInterno = `${String(job.sap_article.descripcion)} (${job.sap_article.molecula_id})`;
         }
       }
 
@@ -3085,6 +3169,24 @@
         historicoCellInner = escapeHtml(historico !== '' ? historico : '—');
       }
 
+      var cantDispTdClass = 'ocr-cantdisp-val';
+      var cantDispCellHtml;
+      if (showHistoricoSpinner) {
+        cantDispTdClass += ' ocr-historico-cell--pending';
+        cantDispCellHtml =
+          '<span class="ocr-inline-spinner-wrap" aria-busy="true">' +
+          '<span class="ocr-inline-spinner"></span>' +
+          '<span class="sr-only">Calculando cantidad a dispensar</span></span>';
+      } else {
+        var ultDispInitial = historico !== '' ? parseFloat(historico) : NaN;
+        var cantDispInitial =
+          isFinite(cantMesNum) && isFinite(ultDispInitial)
+            ? Math.max(0, cantMesNum - ultDispInitial)
+            : null;
+        cantDispCellHtml =
+          cantDispInitial !== null ? escapeHtml(String(Math.round(cantDispInitial))) : '—';
+      }
+
       var secondaryInfo = '';
       if (formaFarm || frecuencia) {
         var parts = [];
@@ -3114,14 +3216,13 @@
       }
       row1 +=
         '</td><td>' + escapeHtml(cantidad) +
-        '</td><td class="' +
-        historicoTdClass +
-        '"' +
-        (numero
-          ? ' data-ocr-historico-article-numero="' + escapeHtml(numero) + '"'
-          : '') +
-        '>' +
-        historicoCellInner +
+        '</td><td class="' + historicoTdClass + '"' +
+        (numero ? ' data-ocr-historico-article-numero="' + escapeHtml(numero) + '"' : '') +
+        '>' + historicoCellInner +
+        '</td><td class="' + cantDispTdClass + '"' +
+        (numero ? ' data-ocr-cantdisp-article-numero="' + escapeHtml(numero) + '"' : '') +
+        (isFinite(cantMesNum) ? ' data-ocr-cantmes="' + cantMesNum + '"' : '') +
+        '>' + cantDispCellHtml +
         '</td></tr>';
 
       var niHtml;
@@ -3143,7 +3244,7 @@
 
       var row2 =
         '<tr class="ocr-article-row ocr-article-row--secondary">' +
-        '<td colspan="3" class="ocr-article-nombreinterno' +
+        '<td colspan="4" class="ocr-article-nombreinterno' +
         (showPending ? ' ocr-barra-cell--pending' : '') +
         '"' +
         (jobId ? ' data-ocr-nombreinterno-job="' + jobId + '"' : '') +
@@ -3220,6 +3321,7 @@
     
     scheduleBarraPolling(payload.barra_jobs || [], payload.result.IPS);
     scheduleInitialHistoricalDisp(payload.barra_jobs || []);
+    scheduleInitialCantDisp(r.Articulos || []);
 
     lastTransactionId = payload.transaction_id;
     discardBtn.hidden = !payload.transaction_id;

--- a/core/apps/home/templates/pages/radicacion_detail.html
+++ b/core/apps/home/templates/pages/radicacion_detail.html
@@ -1945,7 +1945,7 @@
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"></path>
                   </svg>
                 </span>
-                <h2 id="ocr-section-title" class="section-header__title mb-0">Información de la autorización</h2>
+                <h2 id="ocr-section-title" class="section-header__title mb-0">Información de la prescripción</h2>
               </div>
               <div class="ocr-header-actions ms-auto" id="ocrHeaderActions">
                 <span id="ocrSourceBadge" class="ocr-badge ocr-badge--header" hidden></span>
@@ -2744,7 +2744,7 @@
       var ni = data.sap_article.descripcion || '';
       var barra = data.sap_article.barra || '';
       niEl.innerHTML =
-        escapeHtml(ni) +
+        escapeHtml(ni) + ` (${escapeHtml(data.sap_article.molecula_id)})` +
         (barra
           ? ' <span class="ocr-barra-inline">· ' + escapeHtml(barra) + '</span>'
           : '');
@@ -2757,7 +2757,7 @@
   }
 
   function pollBarraJobOnce(jobId, articleNombre, ips, attempt, articleNumero) {
-    // console.log("About to pollBarraJobOnce", jobId, articleNombre, ips, attempt);
+    console.log("About to pollBarraJobOnce", jobId, articleNombre, ips, attempt);
     attempt = attempt || 0;
     if (attempt >= BARRA_POLL_MAX_ATTEMPTS) {
       var timeoutData = {
@@ -2790,25 +2790,21 @@
         return res.json();
       })
       .then(function(data) {
+        // console.log(`Al llamar search-barra de ${articleNombre}, el resultado fue `, data)
         if (!data || data.detail === 'job_not_found') return null;
         if (data.status === 'completado' || data.status === 'fallido') {
+          // console.log(`Actualizando data ${articleNombre}:\n\t\t jobId=${jobId}, articleNumero=${articleNumero}, data.article_numero=${data.article_numero}`)
           updateBarraJobDom(jobId, data);
           appendBarraJobMetaRow(data);
-          var an =
-            data.article_numero != null
-              ? String(data.article_numero)
-              : articleNumero != null
-                ? String(articleNumero)
-                : '';
           if (
             data.status === 'completado' &&
             data.sap_article &&
             data.sap_article.molecula_id != null &&
             String(data.sap_article.molecula_id).trim() !== ''
           ) {
-            applyHistoricalDispForRow(an, String(data.sap_article.molecula_id));
+            applyHistoricalDispForRow(articleNumero, String(data.sap_article.molecula_id));
           } else {
-            restoreUltDispFromOcr(an);
+            restoreUltDispFromOcr(articleNumero);
           }
           return data;
         }
@@ -2827,7 +2823,7 @@
         });
       })
       .catch(function(error) {
-        console.error('Error polling barra job', jobId, articleNombre, ips, attempt,error);
+        console.error('Error polling barra job', jobId, articleNombre, ips, attempt, res, error);
         return new Promise(function(resolve) {
           setTimeout(function() {
             resolve(
@@ -2961,9 +2957,7 @@
     */
     if (!modalContent || articleNumero == null || articleNumero === '') return;
     var an = String(articleNumero);
-    var el = modalContent.querySelector(
-      '[data-ocr-historico-article-numero="' + an + '"]'
-    );
+    var el = modalContent.querySelector('[data-ocr-historico-article-numero="' + an + '"]');
     if (!el) return;
     el.classList.remove('ocr-historico-cell--pending');
     el.textContent = text === undefined || text === null ? '' : String(text);
@@ -3039,9 +3033,9 @@
   function applyHistoricalDispForRow(articleNumero, codMol) {
     /*
     For a given article row (articleNumero) and SAP molecula_id (CodMol), 
-    it asks the cached historical-dispensations list for the current patient document, 
-    computes the sum of CantidadDispensada for that CodMol, then fills the Ult. Disp cell. 
-    If there is no document or no CodMol, it falls back to restoreUltDispFromOcr
+      it asks the cached historical-dispensations list for the current patient document, 
+      calculates the sum of CantidadDispensada for that CodMol, then fills the "Ult. Disp" cell. 
+      If there is no document or no CodMol, it falls back to restoreUltDispFromOcr
     */
     if (!modalContent || articleNumero == null || articleNumero === '') return;
     var an = String(articleNumero);
@@ -3130,13 +3124,13 @@
 
       if (job && job.status === 'completado' && job.sap_article) {
         if (job.sap_article.barra != null && job.sap_article.barra !== '') {
-          barra = String(job.sap_article.barra);
+          barra = job.sap_article.barra;
         }
         if (
           job.sap_article.descripcion != null &&
           job.sap_article.descripcion !== ''
         ) {
-          nombreInterno = `${String(job.sap_article.descripcion)} (${job.sap_article.molecula_id})`;
+          nombreInterno = job.sap_article.descripcion;
         }
       }
 
@@ -3248,7 +3242,7 @@
           (job.error_message || 'Sin coincidencia').slice(0, 240)
         );
       } else {
-        niHtml = nombreInterno ? escapeHtml(nombreInterno) : '';
+        niHtml = nombreInterno;
         if (barra) {
           niHtml += ' <span class="ocr-barra-inline">· ' + escapeHtml(barra) + '</span>';
         }

--- a/core/settings.py
+++ b/core/settings.py
@@ -216,6 +216,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.SessionAuthentication',
     ],
+    'EXCEPTION_HANDLER': 'core.apps.api.exception_handlers.api_exception_handler',
 }
 
 SPECTACULAR_SETTINGS = {


### PR DESCRIPTION
close #243

## Summary by Sourcery

Integrate prescription OCR with Medicar historical dispensations to compute per‑article dispensing quantities, expose a new API for historical dispensation data, and harden OCR error handling and typing/validation.

New Features:
- Add a patient historical dispensations API backed by Medicar, including Pydantic models and serializers that mirror the external service schema.
- Display article molecule identifiers and a new per‑article "Cantidad a dispensar" column in the radicación prescription view, using Medicar history when available.
- Introduce normalization of patient document type values returned by the OCR pipeline and surface more detailed OCR failure reasons to API clients.

Bug Fixes:
- Fix Anthropic provider configuration to read the Anthropic API key from the correct settings constant.
- Improve prescription OCR document mismatch logging to avoid false positives when OCR omits document fields.
- Handle external Medicar responses that return user-not-found errors without crashing the parser.

Enhancements:
- Refine OCR barra lookup prompts and client polling to support molecule-based historical lookups and gracefully fall back to OCR-derived history when needed.
- Calculate and log monthly dispensing quantities with rounding and validation for inconsistent prescription durations.
- Add a global DRF exception handler to return a user-friendly message when the database is temporarily unavailable.

Tests:
- Add unit and API tests for Medicar historical dispensations parsing and the new historical dispensations endpoint, including authentication and error-path coverage.