### PR TITLE
feat: mejorias en querysets

### DIFF
--- a/core/apps/base/legacy_models.py
+++ b/core/apps/base/legacy_models.py
@@ -12,7 +12,7 @@ from core.settings import logger
 
 class MutualserManager(models.Manager):
     def get_by_doc(self, tipo, doc):
-        return self.filter(documento=doc, tipo_documento=tipo).first()
+        return self.filter(documento=doc, tipo_documento=tipo).order_by().only("nombres", "apellido").first()
 
 
 class Mutualser(models.Model):

--- a/core/apps/home/facade.py
+++ b/core/apps/home/facade.py
@@ -1,122 +1,190 @@
+import calendar
 import datetime
 from statistics import mean
 from typing import List
 
-from django.db.models import Count
+from django.db.models import Count, Q
+from django.db.models.functions import TruncMonth
 
 from core.apps.base.models import Radicacion
-from core.apps.home.utils import get_last_month_and_year
+from core.apps.home.utils import get_last_month_and_year, month_end_exclusive, month_start_datetime
 
 
-def listar_radicados_mes(month: int,
-                         args=('datetime', 'numero_radicado', 'ip', 'paciente_cc'),
-                         year: int = 2024) -> List[Radicacion]:
+def listar_radicados_mes(
+    month: int,
+    args=('datetime', 'numero_radicado', 'ip', 'paciente_cc'),
+    year: int = 2024,
+) -> List[Radicacion]:
     """
     Lista todos los radicados de un mes ordenados decrescentemente.
-    :param args:
-    :param month: Obligatório. '04' o '12' o '10' ...
-    :param year: Opcional. '2023'
-    :return:
+    Uses datetime range filters so the DB can use indexes on `datetime`.
     """
+    start = month_start_datetime(year, month)
+    end = month_end_exclusive(year, month)
     return Radicacion.objects.filter(
-        datetime__year=year,
-        datetime__month=month,
+        datetime__gte=start,
+        datetime__lt=end,
     ).order_by('-datetime').values(*args)
 
 
-def listar_uniques_by_field(month: int, field: str, year: int = '2024') -> List[Radicacion]:
+def listar_uniques_by_field(month: int, field: str, year: int = 2024):
     """
-    Lista todos los radicados de un mes sin repetir basado en el
-    field.
+    Lista todos los radicados de un mes sin repetir basado en el field.
     """
+    start = month_start_datetime(year, month)
+    end = month_end_exclusive(year, month)
     return Radicacion.objects.filter(
-        datetime__year=year,
-        datetime__month=month,
+        datetime__gte=start,
+        datetime__lt=end,
     ).order_by(field).distinct(field)
 
 
-def listar_radicados_old_months(month: int, year: int = 2024) -> List[Radicacion]:
-    return Radicacion.objects.filter(
-        datetime__year__lte=year,
-        datetime__month__lt=month
-    ).values('ip', 'paciente_cc', 'datetime')
+def listar_radicados_old_months(month: int, year: int = 2024):
+    """Radicados estrictamente anteriores al inicio del mes calendario dado."""
+    month_start = month_start_datetime(year, month)
+    return Radicacion.objects.filter(datetime__lt=month_start).values(
+        'ip', 'paciente_cc', 'datetime'
+    )
 
 
-def order_radicados_by_mun_mes(month: str, year: str = '2024') -> List[dict]:
+def order_radicados_by_mun_mes(month: int, year: int) -> List[dict]:
     """
-    Lista a cantidad de radicados por municipio en determinado mes/año
-    :param month: Obligatório. '04' o '12' o '10' ...
-    :param year: Opcional. '2023'
-    :return:
-            Ex.:
-                [
-                    {'municipio__name': 'barranquilla',
-                      'municipio__departamento': 'atlántico',
-                      'radicados': 504},
-                     {'municipio__name': 'soledad',
-                      'municipio__departamento': 'atlántico',
-                      'radicados': 395},
-                     {'municipio__name': 'villavicencio',
-                      'municipio__departamento': 'meta',
-                      'radicados': 274},
-                     {'municipio__name': 'malambo',
-                      'municipio__departamento': 'atlántico',
-                      'radicados': 53},
-                    ...
-                    }
-                ]
+    Lista la cantidad de radicados por municipio en determinado mes/año.
     """
-    return list(Radicacion.objects.filter(
-        datetime__year=year,
-        datetime__month=month,
-    ).values('municipio__name', "municipio__departamento").annotate(
-        radicados=Count('id')
-    ).order_by('-radicados'))
+    start = month_start_datetime(year, month)
+    end = month_end_exclusive(year, month)
+    return list(
+        Radicacion.objects.filter(datetime__gte=start, datetime__lt=end)
+        .values('municipio__name', 'municipio__departamento')
+        .annotate(radicados=Count('id'))
+        .order_by('-radicados')
+    )
 
 
 def encontrar_radicado(num):
     return Radicacion.objects.get(numero_radicado=num).values()
 
 
+def count_radicados_in_month_until_calendar_moment(
+    year: int, month: int, ref_day: int, ref_hour: int
+) -> int:
+    """
+    Count radicados in [month_start, month_end) up to the same calendar day/hour
+    as the reference, clamping the day to the last day of that month.
+    """
+    start = month_start_datetime(year, month)
+    end = month_end_exclusive(year, month)
+    last_dom = calendar.monthrange(year, month)[1]
+    eff_day = min(ref_day, last_dom)
+    return (
+        Radicacion.objects.filter(datetime__gte=start, datetime__lt=end)
+        .filter(
+            Q(datetime__day__lt=eff_day)
+            | Q(datetime__day=eff_day, datetime__hour__lte=ref_hour)
+        )
+        .count()
+    )
+
+
+def count_radicados_current_month_until_day(
+    year: int, month: int, current_day: int
+) -> int:
+    """Radicados del mes desde el inicio hasta el día del mes (inclusive), clamped."""
+    start = month_start_datetime(year, month)
+    end = month_end_exclusive(year, month)
+    last_dom = calendar.monthrange(year, month)[1]
+    eff_day = min(current_day, last_dom)
+    return Radicacion.objects.filter(
+        datetime__gte=start,
+        datetime__lt=end,
+        datetime__day__lte=eff_day,
+    ).count()
+
+
 def qty_radicados_hasta_ahora(current_day, current_hour, rads_last_month) -> int:
-    """Calcula la cantidad de radicados del mes anterior hasta el dia equivalente a hoy."""
+    """DEPRECATED: kept for backwards compatibility; prefer count helpers above."""
     return rads_last_month.filter(
-        datetime__day__lte=current_day).exclude(datetime__day=current_day, datetime__hour__gt=current_hour).count()
+        datetime__day__lte=current_day
+    ).exclude(
+        datetime__day=current_day, datetime__hour__gt=current_hour
+    ).count()
 
 
-def crecimiento_con_mes_anterior(current_day, current_hour, rads_current_month, rads_last_month) -> str:
-    count_rads_last_month_until_current_day = qty_radicados_hasta_ahora(current_day, current_hour, rads_last_month)
-    count_rads_current_month_until_current_day = rads_current_month.filter(datetime__day__lte=current_day).count()
-    if count_rads_last_month_until_current_day:
-        crecimiento = int(round((
-                                        (
-                                                    count_rads_current_month_until_current_day - count_rads_last_month_until_current_day) / count_rads_last_month_until_current_day
-                                ) * 100, 2))
+def crecimiento_con_mes_anterior(
+    current_day, current_hour, rads_current_month, rads_last_month
+) -> str:
+    """DEPRECATED: kept for backwards compatibility."""
+    count_rads_last_month_until_current_day = qty_radicados_hasta_ahora(
+        current_day, current_hour, rads_last_month
+    )
+    count_rads_current_month_until_current_day = rads_current_month.filter(
+        datetime__day__lte=current_day
+    ).count()
+    return format_crecimiento_pct(
+        count_rads_current_month_until_current_day,
+        count_rads_last_month_until_current_day,
+    )
+
+
+def format_crecimiento_pct(current_count: int, previous_count: int) -> str:
+    """Build the '+X%' / '-X%' growth label used on the dashboard."""
+    if previous_count:
+        crecimiento = int(
+            round(
+                ((current_count - previous_count) / previous_count) * 100,
+                2,
+            )
+        )
     else:
         crecimiento = 0
-    return f"+{crecimiento}%" if crecimiento > 0 else f"{crecimiento}%"
+    return f'+{crecimiento}%' if crecimiento > 0 else f'{crecimiento}%'
 
 
 def radicados_sin_acta():
     dt = datetime.datetime.now()
-    return Radicacion.objects.select_related('municipio').filter(acta_entrega=None).exclude(
-        datetime__day=dt.day, datetime__month=dt.month, datetime__year=dt.year
-    ).order_by('datetime')
+    return (
+        Radicacion.objects.select_related('municipio')
+        .filter(acta_entrega=None)
+        .exclude(
+            datetime__day=dt.day,
+            datetime__month=dt.month,
+            datetime__year=dt.year,
+        )
+        .order_by('datetime')
+    )
 
 
 def avg_last_n_months(n_months_back: int) -> int:
     """
-    Calcula el promedio de radicados desde el mes anterior hacia atrás.
-    :param n_months_back: Cantidad de meses a considerar en la query.
-    Si se define 1, considera el mes anterior.
-    Si se define 2, considera los dos meses anteriores.
-    :return: Promedio de radicados de los  últimos n meses.
+    Promedio de radicados de los últimos n meses calendario previos al mes actual.
+    Un solo agrupamiento por mes en DB en lugar de N queries COUNT.
     """
-    dt = datetime.datetime.now()
-    qt_per_month = []
+    if n_months_back <= 0:
+        return 0
+
+    now = datetime.datetime.now()
+    cur_y, cur_m = now.year, now.month
+    range_end = month_start_datetime(cur_y, cur_m)
+
+    y, m = cur_y, cur_m
+    months: list[tuple[int, int]] = []
     for _ in range(n_months_back):
-        last_year, last_month = get_last_month_and_year(dt)
-        qt_per_month.append(listar_radicados_mes(month=last_month, year=last_year, args=('pk',)).count())
-        dt = datetime.datetime(year=last_year, month=last_month, day=1)
+        y, m = get_last_month_and_year(datetime.datetime(y, m, 1))
+        months.append((y, m))
+
+    range_start = month_start_datetime(y, m)
+
+    rows = (
+        Radicacion.objects.filter(datetime__gte=range_start, datetime__lt=range_end)
+        .annotate(m=TruncMonth('datetime'))
+        .values('m')
+        .annotate(c=Count('id'))
+    )
+    count_by_trunc = {row['m']: row['c'] for row in rows}
+
+    qt_per_month = []
+    for yy, mm in months:
+        key_dt = month_start_datetime(yy, mm)
+        qt_per_month.append(count_by_trunc.get(key_dt, 0))
 
     return int(mean(qt_per_month))

--- a/core/apps/home/templates/pages/radicacion_detail.html
+++ b/core/apps/home/templates/pages/radicacion_detail.html
@@ -1834,7 +1834,7 @@
               <div class="patient-compact-col">
                 <span class="patient-compact-label">Documento</span>
                 <span class="patient-compact-value">
-                  <span class="copy-value" id="numero_documento_paciente" solo_documento="{{rad.numero_documento_paciente}}">{{ rad.tipo_documento_paciente|default:"--" }}{{ rad.numero_documento_paciente|default:"--" }}</span>
+                  <span class="copy-value" id="numero_documento_paciente" solo_documento="{{rad.numero_documento_paciente}}">{{ rad.tipo_documento_paciente|default:"CC" }}{{ rad.numero_documento_paciente|default:"--" }}</span>
                   {% if rad.paciente_cc %}
                   <button type="button" class="copy-btn" data-copy-text="{{ rad.paciente_cc }}" aria-label="Copiar documento">
                     <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/core/apps/home/utils.py
+++ b/core/apps/home/utils.py
@@ -558,6 +558,18 @@ def user_is_authenticated(user):
         return user.is_authenticated()
 
 
+def month_start_datetime(year: int, month: int) -> datetime.datetime:
+    """First moment of the calendar month (naive; matches USE_TZ=False)."""
+    return datetime.datetime(year, month, 1)
+
+
+def month_end_exclusive(year: int, month: int) -> datetime.datetime:
+    """First moment of the *next* calendar month."""
+    if month == 12:
+        return datetime.datetime(year + 1, 1, 1)
+    return datetime.datetime(year, month + 1, 1)
+
+
 def get_last_month_and_year(dt: 'datetime') -> Tuple:
     if dt.month == 1:
         previous_month = 12

--- a/core/apps/home/views.py
+++ b/core/apps/home/views.py
@@ -3,7 +3,6 @@ import datetime
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView
-from django.db.models.functions import Length
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.csrf import csrf_exempt
 
@@ -11,9 +10,20 @@ from core.apps.base.models import Radicacion
 from core.apps.base.resources.tools import decrypt
 from core.apps.home import facade
 from core.apps.home.context_processors import order_radicados_by_day
-from core.apps.home.facade import order_radicados_by_mun_mes, avg_last_n_months
+from core.apps.home.facade import (
+    avg_last_n_months,
+    count_radicados_current_month_until_day,
+    count_radicados_in_month_until_calendar_moment,
+    format_crecimiento_pct,
+    order_radicados_by_mun_mes,
+)
 from core.apps.home.forms import LoginForm
-from core.apps.home.utils import get_last_month_and_year, MES
+from core.apps.home.utils import (
+    get_last_month_and_year,
+    MES,
+    month_end_exclusive,
+    month_start_datetime,
+)
 from core.settings import logger
 
 
@@ -30,24 +40,74 @@ def ver_soporte_rad(request, value):
 
 @login_required
 def index(request):
-    logger.warning(f'{request.user.username} ha accesado a inicio/ login.')
     if request.user.username not in ('admin', 'logistica'):
+        logger.warning(f'{request.user.username} ha accesado a inicio/ login.')
         logout(request)
         return redirect('base:home')
     dt = datetime.datetime.now()
-    radicados = facade.listar_radicados_mes(month=dt.month, year=dt.year)
-    unique_pacientes_in_month = facade.listar_uniques_by_field(month=dt.month, year=dt.year, field='paciente_cc')
-    old_radicados = facade.listar_radicados_old_months(month=dt.month, year=dt.year)
-    qty_new_pacientes = unique_pacientes_in_month.exclude(
-        paciente_cc__in=old_radicados.values_list('paciente_cc', flat=True)
+    month_start = month_start_datetime(dt.year, dt.month)
+    month_end = month_end_exclusive(dt.year, dt.month)
+
+    radicados = list(
+        Radicacion.objects.filter(
+            datetime__gte=month_start,
+            datetime__lt=month_end,
+        )
+        .order_by('-datetime')
+        .values('datetime', 'numero_radicado', 'ip', 'paciente_cc', 'convenio')
     )
 
-    qty_medicamentos_autorizados = radicados.annotate(text_len=Length('numero_radicado')).filter(text_len__lt=15)
-    qty_medicamentos_no_autorizados = radicados.annotate(text_len=Length('numero_radicado')).filter(text_len__gt=15)
+    unique_cc = {row['paciente_cc'] for row in radicados}
+    qty_pacientes = len(unique_cc)
+
+    if unique_cc:
+        prior_cc = set(
+            Radicacion.objects.filter(
+                datetime__lt=month_start,
+                paciente_cc__in=unique_cc,
+            )
+            .values_list('paciente_cc', flat=True)
+            .distinct()
+        )
+        qty_new_pacientes = len(unique_cc - prior_cc)
+    else:
+        qty_new_pacientes = 0
+
+    qty_medicamentos_autorizados = sum(
+        1 for row in radicados if len(row['numero_radicado'] or '') < 15
+    )
+    qty_medicamentos_no_autorizados = sum(
+        1 for row in radicados if len(row['numero_radicado'] or '') > 15
+    )
+
+    qty_pacientes_foneca = sum(
+        1 for row in radicados if (row['convenio'] or '') == 'foneca'
+    )
+    qty_pacientes_fomag = sum(
+        1 for row in radicados if (row['convenio'] or '') == 'fomag'
+    )
+    qty_pacientes_proteger = sum(
+        1
+        for row in radicados
+        if (row['convenio'] or '') in ('proteger', 'cajacopi')
+    )
+    qty_pacientes_mutualser = sum(
+        1 for row in radicados if (row['convenio'] or '') == 'mutualser'
+    )
+
     last_year, last_month = get_last_month_and_year(dt)
-    rads_last_month = facade.listar_radicados_mes(month=last_month, year=last_year, args=('pk',))
-    qty_rads_mes_anterior_hasta_current_day = facade.qty_radicados_hasta_ahora(dt.day, dt.hour, rads_last_month)
-    crecimiento = facade.crecimiento_con_mes_anterior(dt.day, dt.hour, radicados, rads_last_month)
+    qty_rads_mes_anterior_hasta_current_day = (
+        count_radicados_in_month_until_calendar_moment(
+            last_year, last_month, dt.day, dt.hour
+        )
+    )
+    count_rads_current_month_until_current_day = (
+        count_radicados_current_month_until_day(dt.year, dt.month, dt.day)
+    )
+    crecimiento = format_crecimiento_pct(
+        count_rads_current_month_until_current_day,
+        qty_rads_mes_anterior_hasta_current_day,
+    )
 
     return render(request, "pages/index.html",
                   {
@@ -55,17 +115,17 @@ def index(request):
                       'parent': f'Radicados de {MES[dt.month]} del {dt.year}',
                       'radicados': radicados,
                       'radicados_day': {f"{k}": len(v) for k, v in order_radicados_by_day(radicados).items()},
-                      'radicados_mun': order_radicados_by_mun_mes(dt.month),
-                      'qty_pacientes': unique_pacientes_in_month.count(),
-                      'qty_new_pacientes': qty_new_pacientes.count(),
+                      'radicados_mun': order_radicados_by_mun_mes(dt.month, dt.year),
+                      'qty_pacientes': qty_pacientes,
+                      'qty_new_pacientes': qty_new_pacientes,
                       'porcentaje_crecimiento': crecimiento,
                       'qty_rads_mes_anterior_hasta_current_day': qty_rads_mes_anterior_hasta_current_day,
-                      'qty_medicamentos_autorizados': qty_medicamentos_autorizados.count(),
-                      'qty_medicamentos_no_autorizados': qty_medicamentos_no_autorizados.count(),
-                      'qty_pacientes_foneca': radicados.filter(convenio='foneca').count(),
-                      'qty_pacientes_fomag': radicados.filter(convenio='fomag').count(),
-                      'qty_pacientes_proteger': radicados.filter(convenio='proteger').count() + radicados.filter(convenio='cajacopi').count(),
-                      'qty_pacientes_mutualser': radicados.filter(convenio='mutualser').count(),
+                      'qty_medicamentos_autorizados': qty_medicamentos_autorizados,
+                      'qty_medicamentos_no_autorizados': qty_medicamentos_no_autorizados,
+                      'qty_pacientes_foneca': qty_pacientes_foneca,
+                      'qty_pacientes_fomag': qty_pacientes_fomag,
+                      'qty_pacientes_proteger': qty_pacientes_proteger,
+                      'qty_pacientes_mutualser': qty_pacientes_mutualser,
                       'avg_last_six_months': avg_last_n_months(6),
                   }
                   )


### PR DESCRIPTION
closet #245

## Summary by Sourcery

Optimize monthly radicacion queries and related dashboard calculations to reduce DB load and improve correctness around calendar month boundaries.

Bug Fixes:
- Fix monthly and previous-month radicacion counts to respect exact calendar month boundaries and handle months with fewer days.
- Correct patient and new-patient counts on the dashboard to avoid relying on distinct querysets that can miss or double-count records.
- Ensure Mutualser document lookups return consistently ordered results and only the fields needed.
- Set a sensible default patient document type in the radicacion detail template when none is provided.

Enhancements:
- Refine queryset helpers to use reusable month start/end utilities and range-based datetime filters that better leverage DB indexes.
- Refactor the home index view to compute all dashboard aggregates from a single in-memory monthly queryset instead of multiple DB hits.
- Extract reusable helpers for month-bounded radicacion counting and growth percentage formatting used by the dashboard.
- Add utility functions for computing the start and exclusive end of a calendar month to centralize date boundary logic.