### PR TITLE
fix: tolerate missing wizard photo files without crashing

### DIFF
--- a/core/apps/base/resources/customwizard.py
+++ b/core/apps/base/resources/customwizard.py
@@ -151,6 +151,38 @@ class CustomSessionWizard(SessionWizardView):
         # logger.info(f"{self.request.COOKIES.get('sessionid')[:6]} Al salir de {self.steps.current} las vistas son {list(ls_form_list)}")
         return self.get_form_step_data(form)
 
+    def _clear_stale_step_files(self, step) -> None:
+        """Drop session + in-memory refs for a step whose file is gone from disk."""
+        self.storage.data.setdefault(self.storage.step_files_key, {})[step] = {}
+        for key in [k for k in self.storage._files if k[0] == step]:
+            del self.storage._files[key]
+
+    def get_step_files_safe(self, step):
+        """
+        Like storage.get_step_files, but if the file is missing on disk clear the
+        stale session reference and return None instead of raising.
+        """
+        try:
+            return self.storage.get_step_files(step)
+        except FileNotFoundError:
+            logger.warning(
+                "Archivo ausente para paso %r; limpiando referencia en sesión",
+                step,
+            )
+            self._clear_stale_step_files(step)
+            return None
+
+    def render_next_step(self, form, **kwargs):
+        """Advance to the next step; tolerate missing wizard files on disk."""
+        next_step = self.steps.next
+        new_form = self.get_form(
+            next_step,
+            data=self.storage.get_step_data(next_step),
+            files=self.get_step_files_safe(next_step),
+        )
+        self.storage.current_step = next_step
+        return self.render(new_form, **kwargs)
+
     def render_goto_step(self, *args, **kwargs):
         """
         Es ejecutado cuando se clica en el botón "Atrás", y en caso de clicar
@@ -172,7 +204,13 @@ class CustomSessionWizard(SessionWizardView):
         form = self.get_form(data=self.request.POST, files=self.request.FILES)
         # self.storage.set_step_data(self.steps.current, self.process_step(form))
         self.storage.set_step_files(self.steps.first, self.process_step_files(form))
-        return super().render_goto_step(*args, **kwargs)
+        goto_step = args[0]
+        self.storage.current_step = goto_step
+        form = self.get_form(
+            data=self.storage.get_step_data(self.steps.current),
+            files=self.get_step_files_safe(self.steps.current),
+        )
+        return self.render(form)
 
     def get_form(self, step=None, data=None, files=None):
         """
@@ -213,6 +251,8 @@ class CustomSessionWizard(SessionWizardView):
             try:
                 files = self.storage.get_step_files(form_key)
             except FileNotFoundError:
+                self._clear_stale_step_files(form_key)
+                files = None
                 logger.info(f"tmp/ -> {list(self.file_storage.base_location.iterdir())}")
                 logger.info("IMAGEN ELIMINADA... NO EXISTE MAS !!!!")
                 notify(

--- a/core/apps/base/views_mutualser.py
+++ b/core/apps/base/views_mutualser.py
@@ -219,7 +219,7 @@ class MutualSerAutorizacion(CustomSessionWizard):
             form = self.get_form(
                 step=args[0],
                 data=self.storage.get_step_data(args[0]),
-                files=self.storage.get_step_files(args[0])
+                files=self.get_step_files_safe(args[0])
             )
 
         # Set the current step
@@ -251,6 +251,8 @@ class MutualSerAutorizacion(CustomSessionWizard):
             try:
                 files = self.storage.get_step_files(form_key)
             except FileNotFoundError:
+                self._clear_stale_step_files(form_key)
+                files = None
                 logger.info(f"tmp/ -> {list(self.file_storage.base_location.iterdir())}")
                 logger.info("IMAGEN ELIMINADA... NO EXISTE MAS !!!!")
                 notify(

--- a/core/settings.py
+++ b/core/settings.py
@@ -184,11 +184,6 @@ STATICFILES_DIRS = [BASE_DIR / "frontend/dist"]
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 
-DJANGO_VITE = {
-  "default": {
-    "dev_mode": DEBUG
-  }
-}
 
 # logger = logging.getLogger('django')
 # logging.basicConfig(format='%(asctime)s - %(message)s')

--- a/core/settings.py
+++ b/core/settings.py
@@ -24,6 +24,12 @@ from urllib3.exceptions import InsecureRequestWarning
 # Some EPS HTTP clients call requests with verify=False (see call_api_eps).
 warnings.filterwarnings("ignore", category=InsecureRequestWarning)
 
+# rpaframework logs truststore/certifi INFO on import (RPA.core.certificates); filter
+# survives its init_logger() resetting the logger level during worker boot.
+logging.getLogger("RPA.core.certificates").addFilter(
+    lambda record: record.levelno > logging.INFO
+)
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -72,7 +72,6 @@ INSTALLED_APPS = [
     'drf_spectacular',
     'corsheaders',
     'debug_toolbar',
-    'django_vite',
 ]
 
 MIDDLEWARE = [

--- a/core/settings.py
+++ b/core/settings.py
@@ -180,7 +180,6 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'tmp'
 
 # STATICFILES_DIRS = [BASE_DIR / "build/static", BASE_DIR / "build"]
-STATICFILES_DIRS = [BASE_DIR / "frontend/dist"]
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 import logging
+import warnings
 from functools import partial
 from os.path import join
 from pathlib import Path
@@ -18,6 +19,10 @@ import pyrebase
 import sentry_sdk
 from decouple import config
 from dj_database_url import parse
+from urllib3.exceptions import InsecureRequestWarning
+
+# Some EPS HTTP clients call requests with verify=False (see call_api_eps).
+warnings.filterwarnings("ignore", category=InsecureRequestWarning)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -36,7 +41,6 @@ PRODUCTION = config("PRODUCTION", cast=bool, default=False)
 
 ALLOWED_HOSTS = [config('IP', cast=str), 'test-domicilios.logifarma.com.co',
                  'domicilios.logifarma.com.co',
-                 'radicatudomicilio.herokuapp.com',
                  '*']
 #Django debug toolbar
 INTERNAL_IPS = ['127.0.0.1']
@@ -67,7 +71,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'drf_spectacular',
     'corsheaders',
-    "debug_toolbar",
+    'debug_toolbar',
+    'django_vite',
 ]
 
 MIDDLEWARE = [
@@ -176,8 +181,15 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'tmp'
 
 # STATICFILES_DIRS = [BASE_DIR / "build/static", BASE_DIR / "build"]
+STATICFILES_DIRS = [BASE_DIR / "frontend/dist"]
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
+
+DJANGO_VITE = {
+  "default": {
+    "dev_mode": DEBUG
+  }
+}
 
 # logger = logging.getLogger('django')
 # logging.basicConfig(format='%(asctime)s - %(message)s')


### PR DESCRIPTION
Clear stale session refs when tmp/ fotoFormulaMedica files are gone so render_next_step no longer raises FileNotFoundError (DOMICILIOS-2PJ). Fixes #247

## Summary by Sourcery

Handle missing wizard step file uploads gracefully by clearing stale session references instead of raising errors when advancing, going back, or finishing the wizard.

Bug Fixes:
- Prevent FileNotFoundError when navigating wizard steps whose uploaded files have been removed from disk.
- Ensure render_done completes even if temporary wizard upload files are missing by clearing associated session state.

Enhancements:
- Introduce a safe step file retrieval helper that logs and cleans up stale wizard file references before continuing navigation.